### PR TITLE
Corrected v.minor text issue on scripts page.

### DIFF
--- a/src/Website/Views/Documentation/Scripts.cshtml
+++ b/src/Website/Views/Documentation/Scripts.cshtml
@@ -1,7 +1,7 @@
 ﻿<h1>Scripts</h1>
 <p>
 To correctly sort your script files, Cassette looks for XML-style reference comments.
-(These are the what Visual Studio uses to give you intellisense.) The idea is that if File-B references File-A
+(These are what Visual Studio uses to give you intellisense.) The idea is that if File-B references File-A
 then File-A is included the HTML before File-B, because File-B depends on File-A.
 </p>
 <p>Here is an example JavaScript file with two references:</p>


### PR DESCRIPTION
Very minor:

> "These are <del>the</del> what Visual Studio uses to give you intellisense."
