### PR TITLE
Changed LineBasedAssetReferenceParser to process the entire file for references

### DIFF
--- a/src/Cassette/ModuleProcessing/LineBasedAssetReferenceParser.cs
+++ b/src/Cassette/ModuleProcessing/LineBasedAssetReferenceParser.cs
@@ -33,10 +33,6 @@ namespace Cassette.ModuleProcessing
                     {
                         asset.AddReference(match.Groups["path"].Value, lineNumber);
                     }
-                    else
-                    {
-                        break;
-                    }
                 }
             }
         }


### PR DESCRIPTION
If the references weren't at the beginning of the file they would be skipped.  I removed a break from the processing so that the entire file is scanned.
