### PR TITLE
CassetteHttpModule breaking ScriptResource.axd and WebResource.axd requests

### DIFF
--- a/src/Cassette.Web/CassetteHttpModule.cs
+++ b/src/Cassette.Web/CassetteHttpModule.cs
@@ -13,6 +13,12 @@ namespace Cassette.Web
         void HttpApplicationBeginRequest(object sender, EventArgs e)
         {
             var context = new HttpContextWrapper(((HttpApplication)sender).Context);
+
+            // Fix for dealing with empty responses for ScriptResource.axd and WebResource.axd files
+            // http://forums.asp.net/t/1550676.aspx/1
+            if (context.Request.Path.ToLower().Contains(".axd"))
+                return;
+            
             StartUp.CassetteApplication.OnBeginRequest(context);
         }
 


### PR DESCRIPTION
Fix for Issue #28 CassetteHttpModule breaking ScriptResource.axd and WebResource.axd requests
