### PR TITLE
Better handling of subfolders in module.txt

### DIFF
--- a/src/Cassette.UnitTests/ModuleDescriptorReader.cs
+++ b/src/Cassette.UnitTests/ModuleDescriptorReader.cs
@@ -83,6 +83,41 @@ namespace Cassette
         }
 
         [Fact]
+        public void HandlesSlashesAsDirectorySeparators()
+        {
+            char systemPathSeparator = Path.DirectorySeparatorChar;
+            string[] givenFiles = new[]
+            {
+                "folder" + systemPathSeparator + "test1.js"
+                , "folder" + systemPathSeparator + "test2.js"
+            };
+
+            Console.WriteLine(givenFiles[0]);
+            Console.WriteLine(givenFiles[1]);
+
+            FilesExist(givenFiles);
+            var reader = GetReader("folder/test1.js\nfolder/test2.js");
+            var result = reader.Read();
+            result.AssetFilenames.SequenceEqual(givenFiles).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void HandlesBackslashesAsDirectorySeparators()
+        {
+            char systemPathSeparator = Path.DirectorySeparatorChar;
+            string[] givenFiles = new[]
+            {
+                "folder" + systemPathSeparator + "test1.js"
+                , "folder" + systemPathSeparator + "test2.js"
+            };
+
+            FilesExist(givenFiles);
+            var reader = GetReader("folder\\test1.js\nfolder\\test2.js");
+            var result = reader.Read();
+            result.AssetFilenames.SequenceEqual(givenFiles).ShouldBeTrue();
+        }
+
+        [Fact]
         public void ThrowsExceptionWhenFileNotFound()
         {
             FilesExist("test1.js");

--- a/src/Cassette.UnitTests/ModuleDescriptorReader.cs
+++ b/src/Cassette.UnitTests/ModuleDescriptorReader.cs
@@ -121,6 +121,24 @@ namespace Cassette
         }
 
         [Fact]
+        public void DirectoryWithAsteriskIncludesAllFilesFromSubdirectory()
+        {
+            FilesExist("shared\\shared-test1.js", "shared\\shared-test2.js", "app\\app-test1.js", "app\\app-test2.js");
+            var reader = GetReader("shared\\*\napp\\*");
+            var result = reader.Read();
+            result.AssetFilenames.SequenceEqual(new[] { "shared\\shared-test1.js", "shared\\shared-test2.js", "app\\app-test1.js", "app\\app-test2.js" }).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void DirectoryWithAsteriskIncludesAllFilesFromSubdirectoryNotAlreadyAdded()
+        {
+            FilesExist("shared\\shared-test1.js", "shared\\shared-test2.js", "app\\app-test1.js", "app\\app-test2.js");
+            var reader = GetReader("shared\\shared-test2.js\nshared\\*\napp\\*");
+            var result = reader.Read();
+            result.AssetFilenames.SequenceEqual(new[] { "shared\\shared-test2.js", "shared\\shared-test1.js", "app\\app-test1.js", "app\\app-test2.js" }).ShouldBeTrue();
+        }
+
+        [Fact]
         public void GivenAssetsSectionReadReturnsAssetFilenames()
         {
             FilesExist("test.js");

--- a/src/Cassette/ModuleDescriptorReader.cs
+++ b/src/Cassette/ModuleDescriptorReader.cs
@@ -99,6 +99,12 @@ namespace Cassette
 
         void ParseAsset(string line)
         {
+            char directorySeparator = Path.DirectorySeparatorChar;
+
+            line = line
+                .Replace('/', directorySeparator)
+                .Replace('\\', directorySeparator);
+
             if (line == "*")
             {
                 foreach (var filename in allAssetfilenames.Except(assetFilenames))
@@ -106,7 +112,7 @@ namespace Cassette
                     assetFilenames.Add(filename);
                 }
             }
-            else if (line.EndsWith("\\*"))
+            else if (line.EndsWith(directorySeparator + "*"))
             {
                 foreach (var filename in allAssetfilenames.Except(assetFilenames))
                 {

--- a/src/Cassette/ModuleDescriptorReader.cs
+++ b/src/Cassette/ModuleDescriptorReader.cs
@@ -106,6 +106,17 @@ namespace Cassette
                     assetFilenames.Add(filename);
                 }
             }
+            else if (line.EndsWith("\\*"))
+            {
+                foreach (var filename in allAssetfilenames.Except(assetFilenames))
+                {
+                    string directory = line.Substring(0, line.Length - 1);
+                    if (filename.StartsWith(directory))
+                    {
+                        assetFilenames.Add(filename);
+                    }
+                }
+            }
             else if (FileExists(line))
             {
                 if (assetFilenames.Contains(line))


### PR DESCRIPTION
Hi,
I started using Cassette today (great job btw) and it lacked some functionality for my particular script folder structure, which is:
- /scripts
  - /lib
    - jquery
    - jqueryui
    - ...
  - /app
    - /shared
      - some-common-functionality.js
    - /views
      - home.js

I want to use PerSubDirectorySource, but also want to make sure that scripts from /app/shared folder get loaded first.
So I added this functionality to module.txt config file, it now can look like this in my 'app' module:

shared/*
*

I also added a change that allows both slashes and backslashes to be used in module.txt as dir separators.

Cheers,
Maciej Aniserowicz
