### PR TITLE
PlaceholderTracker Performance improvement 

### DIFF
--- a/src/Cassette/PlaceholderTracker.cs
+++ b/src/Cassette/PlaceholderTracker.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Text;
+using System.Linq;
 
 namespace Cassette
 {
@@ -17,12 +17,7 @@ namespace Cassette
 
         public string ReplacePlaceholders(string html)
         {
-            var builder = new StringBuilder(html);
-            foreach (var item in creationFunctions)
-            {
-                builder.Replace(item.Key.ToString(), item.Value());
-            }
-            return builder.ToString();
+            return creationFunctions.Aggregate(html, (current, item) => current.Replace(item.Key.ToString(), item.Value()));
         }
     }
 }


### PR DESCRIPTION
Whilst investigatiing page performance I found a large percent taken up by cassette's PlaceholderTracker due to the use of the StringBuilder which appears to take a long time to construct.

doTrace

![GitHub Logo](http://i.imgur.com/KH3Pi.png)

![GitHub Logo](http://i.imgur.com/9BoyM.png)
