### PR TITLE
Changed raw file extensions so they use a dot instead of an underscore

### DIFF
--- a/src/Cassette.UnitTests/Web/CassetteRouting.cs
+++ b/src/Cassette.UnitTests/Web/CassetteRouting.cs
@@ -96,17 +96,17 @@ namespace Cassette.Web
     public class UrlGenerator_CreateImageUrl_Tests : CassetteRouting_Tests
     {
         [Fact]
-        public void CreateRawFileUrlReturnsUrlWithRoutePrefixAndPathWithoutTildeAndHashAndExtensionDotConvertedToUnderscore()
+        public void CreateRawFileUrlReturnsUrlWithRoutePrefixAndPathWithoutTildeAndHash()
         {
             var url = routing.CreateRawFileUrl("~/test.png", "hash");
-            url.ShouldStartWith("_cassette/file/test_hash_png");
+            url.ShouldStartWith("_cassette/file/test_hash.png");
         }
 
         [Fact]
         public void ConvertsToForwardSlashes()
         {
             var url = routing.CreateRawFileUrl("~\\test\\foo.png", "hash");
-            url.ShouldEqual("_cassette/file/test/foo_hash_png");
+            url.ShouldEqual("_cassette/file/test/foo_hash.png");
         }
 
         [Fact]
@@ -200,7 +200,7 @@ namespace Cassette.Web
         [Fact]
         public void RawFileUrlIsMappedToRawFileHandler()
         {
-            SetupAppRelativeCurrentExecutionFilePath("~/_cassette/file/test_coffee");
+            SetupAppRelativeCurrentExecutionFilePath("~/_cassette/file/test.coffee");
 
             var routeData = routes.GetRouteData(httpContext.Object);
             var httpHandler = routeData.RouteHandler.GetHttpHandler(new RequestContext(httpContext.Object, routeData));

--- a/src/Cassette.Web/CassetteRouting.cs
+++ b/src/Cassette.Web/CassetteRouting.cs
@@ -68,7 +68,7 @@ namespace Cassette.Web
             var name = filename.Substring(0, dotIndex);
             var extension = filename.Substring(dotIndex + 1);
             
-            return urlModifier.Modify(string.Format("{0}/file/{1}_{2}_{3}",
+            return urlModifier.Modify(string.Format("{0}/file/{1}_{2}.{3}",
                 RoutePrefix,
                 ConvertToForwardSlashes(name),
                 hash,

--- a/src/Cassette.Web/RawFileRequestHandler.cs
+++ b/src/Cassette.Web/RawFileRequestHandler.cs
@@ -46,7 +46,7 @@ namespace Cassette.Web
         public void ProcessRequest(HttpContext unused)
         {
             var path = routeData.GetRequiredString("path");
-            var match = Regex.Match(path, @"^(?<filename>.*)_[a-z0-9]+_(?<extension>[a-z]+)$", RegexOptions.IgnoreCase);
+            var match = Regex.Match(path, @"^(?<filename>.*)_[a-z0-9]+\.(?<extension>[a-z]+)$", RegexOptions.IgnoreCase);
             if (match.Success == false)
             {
                 NotFound(path);


### PR DESCRIPTION
This was prompted by `*.htc` files being ignored by IE when the dot was replaced with an underscore. For consistency all raw files use this approach now.

I also made the `RawFileRequestHandler_Tests` class public so that its tests could be run by my test runner (TestDriven.net).
