### PR TITLE
[Fixes #159] Cassette should not create a bundle for empty directories (AddPerSubDirectory)

### DIFF
--- a/src/Cassette.UnitTests/Configuration/BundleCollectionExtensions.cs
+++ b/src/Cassette.UnitTests/Configuration/BundleCollectionExtensions.cs
@@ -220,6 +220,16 @@ namespace Cassette.Configuration
         }
 
         [Fact]
+        public void GivenEmptyDirectory_WhenAddPerSubDirectory_ThenDirectoryIsIgnored()
+        {
+            CreateDirectory("test");
+
+            bundles.AddPerSubDirectory<TestableBundle>("~");
+
+            bundles.ShouldBeEmpty();
+        }
+
+        [Fact]
         public void GivenTopLevelDirectoryHasFilesAndSubDirectory_WhenAddPerSubDirectory_ThenBundleAlsoCreatedForTopLevel()
         {
             File.WriteAllText(Path.Combine(tempDirectory, "file-a.js"), "");

--- a/src/Cassette/Configuration/BundleCollectionExtensions.cs
+++ b/src/Cassette/Configuration/BundleCollectionExtensions.cs
@@ -210,15 +210,19 @@ namespace Cassette.Configuration
             foreach (var directory in directories)
             {
                 Trace.Source.TraceInformation(string.Format("Creating {0} for {1}", typeof(T).Name, directory.FullPath));
-                var descriptorFile = TryGetDescriptorFile(directory);
-                var descriptor = descriptorFile.Exists
-                    ? new BundleDescriptorReader(descriptorFile).Read()
-                    : new BundleDescriptor { AssetFilenames = { "*" } };
                 var allFiles = fileSearch.FindFiles(directory);
-                var bundle = bundleFactory.CreateBundle(directory.FullPath, allFiles, descriptor);
-                if (customizeBundle != null) customizeBundle(bundle);
-                TraceAssetFilePaths(bundle);
-                bundleCollection.Add(bundle);
+                if (allFiles.Any())
+                {
+                    var descriptorFile = TryGetDescriptorFile(directory);
+                    var descriptor = descriptorFile.Exists
+                                         ? new BundleDescriptorReader(descriptorFile).Read()
+                                         : new BundleDescriptor { AssetFilenames = { "*" } };
+
+                    var bundle = bundleFactory.CreateBundle(directory.FullPath, allFiles, descriptor);
+                    if (customizeBundle != null) customizeBundle(bundle);
+                    TraceAssetFilePaths(bundle);
+                    bundleCollection.Add(bundle);
+                }
             }
         }
 


### PR DESCRIPTION
For issue #159 I added a test to assert that no bundles are created when an empty directory is encountered. If the file search returns 0 files, that means we shouldn't create a bundle. The previous code would create a bundle even if the file search returned 0 files.

Let me know if there's something I'm missing or need to change.
