### PR TITLE
Support Razor Templates in AddInlineScript

### DIFF
--- a/src/Cassette.UnitTests/Web/Bundles.cs
+++ b/src/Cassette.UnitTests/Web/Bundles.cs
@@ -52,6 +52,13 @@ namespace Cassette.Web
         }
 
         [Fact]
+        public void AddInlineScriptWithLambdaAddsReferenceToInlineScriptBundle()
+        {
+            Bundles.AddInlineScript((Func<object, object>)((a) => { return "content"; }), "location");
+            referenceBuilder.Verify(b => b.Reference(It.Is<Bundle>(bundle => bundle is InlineScriptBundle), "location"));
+        }
+
+        [Fact]
         public void AddPageDataWithDataObjectAddsReferenceToPageDataScriptBundle()
         {
             Bundles.AddPageData("content", new { data = 1 }, "location");

--- a/src/Cassette.Views/Bundles.cs
+++ b/src/Cassette.Views/Bundles.cs
@@ -33,6 +33,23 @@ namespace Cassette.Views
         }
 
         /// <summary>
+        /// Adds a page reference to an inline JavaScript block.
+        /// </summary>
+        /// <param name="scriptContent">The Razor template for the Javascript code.</param>
+        /// <param name="pageLocation">The optional page location of the script. This controls where it will be rendered.</param>
+        /// <code lang="CS">
+        /// @{
+        ///   Bundles.AddInlineScript(@<text>
+        ///     var foo = "Hello World";
+        ///     alert( foo );</text>);
+        /// }
+        /// </code>
+        public static void AddInlineScript(Func<object, object> scriptContent, string pageLocation = null)
+        {
+            AddInlineScript(scriptContent(null).ToString(), pageLocation);
+        }
+
+        /// <summary>
         /// Add a page reference to a script that initializes a global JavaScript variable with the given data.
         /// </summary>
         /// <param name="globalVariable">The name of the global JavaScript variable to assign.</param>

--- a/src/Website/Views/Documentation/BundlesHelper.cshtml
+++ b/src/Website/Views/Documentation/BundlesHelper.cshtml
@@ -48,3 +48,13 @@ in different parts of the page. For example, some scripts belong in the &lt;head
 <p>Use overloads of the <code>Render*</code> methods to specify the page location being rendered.</p>
 
 <pre><code>@@Bundles.RenderScripts("body")</code></pre>
+
+<h2>Inline Scripts</h2>
+<p>Ad-hoc inline page scripts can be managed by using the <code>AddInlineScript</code> method.</p>
+<pre><code>@@{
+    var message = "Hello World!";
+    Bundles.AddInlineScript(@@&lt;text&gt;
+      alert('@@message');
+    &lt;/text&gt;);
+}</code></pre>
+<p>This will add a <code>&lt;script&gt;</code> block to the page that displays a whitty message to visitors.</p>


### PR DESCRIPTION
Markdown is going to be the death of me :)

I created an overload to AddInlineScript to support the `@<text></text>` razor template format.  It makes for nicer looking code and solves world hunger.  Well.  I might be using marketing speak there a little bit.

```
@{
   ViewBag.Message = "Hello World!";

   Bundles.AddInlineScript(@<text>
     var foo = 'bar',
          bar = 'foo';

     alert('@ViewBag.Message' + bar + foo);</text>);
}
```
