### PR TITLE
It is impossible to determine what is causing LESS compilation errors

### DIFF
--- a/src/Cassette/Stylesheets/LessCompiler.cs
+++ b/src/Cassette/Stylesheets/LessCompiler.cs
@@ -52,25 +52,36 @@ namespace Cassette.Stylesheets
                 get { return string.Join(Environment.NewLine, errors).Trim(); }
             }
 
+            public void Log(LogLevel level, string message)
+            {
+                switch (level)
+                {
+                    case LogLevel.Info: Info(message); break;
+                    case LogLevel.Debug: Debug(message); break;
+                    case LogLevel.Warn: Warn(message); break;
+                    case LogLevel.Error: Error(message); break;
+                }
+            }
+
             public void Error(string message)
             {
                 errors.Add(message);
-            }
-
-            public void Log(LogLevel level, string message)
-            {
+                Trace.Source.TraceInformation(message);
             }
 
             public void Info(string message)
             {
+                Trace.Source.TraceInformation(message);
             }
 
             public void Debug(string message)
             {
+                Trace.Source.TraceInformation(message);
             }
 
             public void Warn(string message)
             {
+                Trace.Source.TraceInformation(message);
             }
         }
 


### PR DESCRIPTION
While trying to use Cassette with Twitter Bootstrap I was getting a "syntax error on line 7" - which isn't terribly descriptive. After making this change I found out that Cassette was still grabbing all the files in the bundle directory - and as such it was failing on the first file.

This fix will simply write the LESS compiler log info to the `Trace.Source` so that when a debugger is attached you can see more descriptive compilation messages (as logging Error alone isn't good enough - that will only contain e.g. "syntax error on line 7").
- Adding tracing to the dotless logger.
