### PR TITLE
Conditional Comments around InlineScripts

### DIFF
--- a/src/Cassette/Scripts/InlineScriptBundle.cs
+++ b/src/Cassette/Scripts/InlineScriptBundle.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cassette.Configuration;
+using System.Text;
 
 namespace Cassette.Scripts
 {
@@ -18,12 +19,29 @@ namespace Cassette.Scripts
 
         internal override string Render()
         {
-            return string.Format(
+            var html = new StringBuilder();
+
+            var hasCondition = !string.IsNullOrEmpty(Condition);
+            if (hasCondition)
+            {
+                html.AppendFormat(HtmlConstants.ConditionalCommentStart, Condition);
+                html.AppendLine();
+            }
+
+            html.Append(string.Format(
                 HtmlConstants.InlineScriptHtml,
                 HtmlAttributes.CombinedAttributes,
                 Environment.NewLine,
                 scriptContent
-            );
+            ));
+
+            if (hasCondition)
+            {
+                html.AppendLine();
+                html.Append(HtmlConstants.ConditionalCommentEnd);
+            }
+
+            return html.ToString();
         }
     }
 }


### PR DESCRIPTION
I have updated InlineScriptBundle.cs by copying some of the render code from ScriptBunderHtmlRenderer.  This allows for conditional comments for IE to be placed around inline scripts added through Bundles.AddInlineScript().

e.g. Bundles.AddInlineScript("var ie7Below = true;", "head", b => b.Condition = "lte IE 7");

will produce 

<!--[if lte IE 7]>
<script type="text/javascript">
var ie7Below = true;
</script>
<![endif]-->
