### PR TITLE
Way to not parse xml js references so you can have intellisense without file being parsed by cassette

### DIFF
--- a/src/Cassette/Scripts/JavaScriptReferenceParser.cs
+++ b/src/Cassette/Scripts/JavaScriptReferenceParser.cs
@@ -20,8 +20,12 @@ namespace Cassette.Scripts
         protected override IEnumerable<string> ParsePaths(string comment, IAsset sourceAsset, int lineNumber)
         {
             var simplePaths = base.ParsePaths(comment, sourceAsset, lineNumber);
-            var xmlCommentPaths = ParseXmlDocCommentPaths(comment);
-            return simplePaths.Concat(xmlCommentPaths);
+			if (!comment.EndsWith("-ignore"))
+			{
+				var xmlCommentPaths = ParseXmlDocCommentPaths(comment);
+				return simplePaths.Concat(xmlCommentPaths);
+			}
+			return simplePaths;
         }
 
         static IEnumerable<string> ParseXmlDocCommentPaths(string comment)

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -80,6 +80,7 @@
     <Content Include="assets\scripts\disqus\disqus.js" />
     <Content Include="assets\scripts\jquery\jquery.js" />
     <Content Include="assets\scripts\home\tweets.js" />
+    <Content Include="assets\vsdoc\something-vsdoc.js" />
     <Content Include="assets\styles\buttons.css" />
     <Content Include="assets\styles\code.css" />
     <Content Include="assets\styles\documentation.css" />

--- a/src/Website/assets/scripts/home/tweets.js
+++ b/src/Website/assets/scripts/home/tweets.js
@@ -1,4 +1,7 @@
 ﻿/// <reference path="~/assets/scripts/jquery/jquery.js"/>
+/// <reference path="../../vsdoc/something-vsdoc.js" /> -ignore
+
+
 $(function () {
     var tweets = $(".tweets");
     var tweetIndex = 0;

--- a/src/Website/assets/vsdoc/something-vsdoc.js
+++ b/src/Website/assets/vsdoc/something-vsdoc.js
@@ -1,0 +1,1 @@
+﻿var thisShouldBeIgnored = function() { return; }


### PR DESCRIPTION
Added "-ignore" to xml js references as a way to get intellisense but not be parsed by Cassette/Scripts/JavaScriptReferenceParser.cs

Example:
```/// <reference path="~/assets/scripts/jquery/jquery.js"/>
/// <reference path="../../vsdoc/something-vsdoc.js" /> -ignore

```

something-vsdoc.js won't be parsed by cassette and you'll still get intellisense

Another example might be if you have two js files that have to refer to each other, cassette currently complains about cyclical dependency which may actually be a valid use of js in some cases, such as two files both containing globally accessible variables or functions.

Signed-off-by: Patrick Scott <patrickscott88@gmail.com>



```
