### PR TITLE
Allow <script> tags in Bundles.AddInlineScript

### DIFF
--- a/src/Cassette.UnitTests/Scripts/InlineScriptBundle.cs
+++ b/src/Cassette.UnitTests/Scripts/InlineScriptBundle.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Should;
 using Xunit;
 
@@ -61,6 +61,50 @@ namespace Cassette.Scripts
                 "var x = 1;" + Environment.NewLine +
                 "</script>" + Environment.NewLine +
                 "<!-- <![endif]-->"
+            );
+        }
+
+        [Fact]
+        public void GivenInlineScriptBundleWithScriptTag_WhenRender_ThenScriptNotCreated()
+        {
+            var bundle = new InlineScriptBundle("<script type=\"text/javascript\">var x = 1;</script>");
+            var html = bundle.Render();
+            html.ShouldEqual(
+                "<script type=\"text/javascript\">var x = 1;</script>"
+            );
+        }
+
+        [Fact]
+        public void GivenInlineScriptBundleWithScriptTagNoType_WhenRender_ThenScriptNotCreated()
+        {
+            var bundle = new InlineScriptBundle("<script>var x = 1;</script>");
+            var html = bundle.Render();
+            html.ShouldEqual(
+                "<script>var x = 1;</script>"
+            );
+        }
+
+        [Fact]
+        public void GivenInlineScriptBundleWithScriptTagAndAttributes_WhenRender_ThenScriptNotCreated()
+        {
+            var bundle = new InlineScriptBundle("<script type=\"text/javascript\">var x = 1;</script>");
+            bundle.HtmlAttributes.Add("class", "none");
+
+            var html = bundle.Render();
+            html.ShouldEqual(
+                "<script class=\"none\" type=\"text/javascript\">var x = 1;</script>"
+            );
+        }
+
+        [Fact]
+        public void GivenInlineScriptBundleWithScriptTagAndAttributesNoType_WhenRender_ThenScriptNotCreated()
+        {
+            var bundle = new InlineScriptBundle("<script>var x = 1;</script>");
+            bundle.HtmlAttributes.Add("class", "none");
+
+            var html = bundle.Render();
+            html.ShouldEqual(
+                "<script class=\"none\">var x = 1;</script>"
             );
         }
     }

--- a/src/Cassette/Scripts/InlineScriptBundle.cs
+++ b/src/Cassette/Scripts/InlineScriptBundle.cs
@@ -1,9 +1,10 @@
-﻿using System;
+using System;
+using System.Text.RegularExpressions;
 using Cassette.Configuration;
 
 namespace Cassette.Scripts
 {
-    class InlineScriptBundle : ScriptBundle
+    internal class InlineScriptBundle : ScriptBundle
     {
         readonly string scriptContent;
 
@@ -16,15 +17,34 @@ namespace Cassette.Scripts
         {
         }
 
-        internal override string Render()
+        static readonly Regex DetectScriptRegex = new Regex(@"\A \s* <script \b",
+                                                            RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.IgnorePatternWhitespace);
+        /// <summary>
+        /// Handle cases of the content already wrapped in a &lt;script&gt; tag.
+        /// </summary>
+        /// <returns></returns>
+        protected string GetScriptContent()
         {
-            var content = string.Format(
+            var isContentScriptTag = scriptContent != null &&
+                                     DetectScriptRegex.IsMatch(scriptContent, 0);
+            var htmlAttributes = HtmlAttributes.CombinedAttributes; // should start with a space
+
+            if (isContentScriptTag)
+            {
+                return DetectScriptRegex.Replace(scriptContent,
+                    m => m.Value + htmlAttributes, 1, 0); // don't need a space after the attributes - the regex is checking for "\b"
+            }
+            return String.Format(
                 HtmlConstants.InlineScriptHtml,
-                HtmlAttributes.CombinedAttributes,
+                htmlAttributes,
                 Environment.NewLine,
                 scriptContent
-            );
+                );
+        }
 
+        internal override string Render()
+        {
+            var content = GetScriptContent();
             var conditionalRenderer = new ConditionalRenderer();
             return conditionalRenderer.Render(Condition, html => html.Append(content));
         }


### PR DESCRIPTION
I've added an option to use `<script>` tags when adding inline scripts:

```
Bundles.AddInlineScript(@<script type="text/javascript">var i = 1;</script>);
```

(until now they would have been wrapped in another `<script>` tag)

With this syntax, Visual Studio can offer IntelliSense and syntax highlighting, which is better than the current `Bundles.AddInlineScript(@<text>var i = 1;</text>)` option, which shows the script as plain text. 

The fix is pretty basic: if the inline content starts with `\s*<script\b`, it will not be wrapped in another script tag. I've also enabled injecting html attributes into the script.

I've also added text cases for the new option.

(please note this is my first pull request on github, so let me know if I did anything wrong)
