### PR TITLE
RegisterTemplateWithJQueryTmpl no longer assumes the $ alias for jQuery

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,6 +87,7 @@
             TaskDirectory="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v10.0\Web\" />
 
         <MakeDir Directories="$(OutputDir)"/>
+        <MakeDir Directories="$(PackageOutputDir)"/>
         <Exec Command="nuget pack src\%(NugetProject.Identity)\%(NugetProject.Identity).nuspec -symbols -Version $(Version) -OutputDirectory $(PackageOutputDir)"/>
     </Target>
 

--- a/src/Cassette.Aspnet/CassetteHttpModule.cs
+++ b/src/Cassette.Aspnet/CassetteHttpModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Security;
 using System.Text.RegularExpressions;
 using System.Web;
 
@@ -65,11 +66,16 @@ namespace Cassette.Aspnet
 
         static bool IsRunningInCassini()
         {
-            return AppDomain.CurrentDomain
-                .GetAssemblies()
-                .Any(
-                    a => a.FullName.StartsWith("WebDev.WebHost")
-                );
+            try
+            {
+                // detects cassini or drop in replacement cassinidev (which does not have a managed assembly we can sniff)
+                return Process.GetCurrentProcess().ProcessName.StartsWith("WebDev.WebServer");
+            }
+            catch(SecurityException)
+            {
+                // assume if not in full trust then we're not using cassini
+                return false;
+            }
         }
 
         void RewriteFileRequests()

--- a/src/Cassette.JQueryTmpl/RegisterTemplateWithJQueryTmpl.cs
+++ b/src/Cassette.JQueryTmpl/RegisterTemplateWithJQueryTmpl.cs
@@ -19,7 +19,7 @@ namespace Cassette.HtmlTemplates
             {
                 var id = bundle.GetTemplateId(asset);
                 var template = openSourceStream().ReadToEnd();
-                return string.Format("$.template('{0}', {1});{2}", id, template, Environment.NewLine).AsStream();
+                return string.Format("jQuery.template('{0}', {1});{2}", id, template, Environment.NewLine).AsStream();
             };
         }
     }

--- a/src/Cassette.UnitTests/HtmlTemplates/RegisterTemplateWithJQueryTmpl.cs
+++ b/src/Cassette.UnitTests/HtmlTemplates/RegisterTemplateWithJQueryTmpl.cs
@@ -18,7 +18,7 @@ namespace Cassette.HtmlTemplates
 
             var getResult = transformer.Transform(() => "TEMPLATE".AsStream(), asset.Object);
 
-            getResult().ReadToEnd().ShouldEqual("$.template('asset', TEMPLATE);" + Environment.NewLine);
+            getResult().ReadToEnd().ShouldEqual("jQuery.template('asset', TEMPLATE);" + Environment.NewLine);
         }
     }
 }

--- a/src/Cassette/Cassette.nutrans
+++ b/src/Cassette/Cassette.nutrans
@@ -4,7 +4,7 @@
     <id xdt:Transform="Insert">Cassette</id>
     <description xdt:Transform="Insert">Important: This is just the core library for Cassette. You probably want to install the Cassette.Aspnet package for ASP.NET support.</description>
     <dependencies xdt:Transform="Insert">
-      <dependency id="AjaxMin" version="4.46" />
+      <dependency id="AjaxMin" version="4.51" />
       <dependency id="Newtonsoft.Json" version="4.0" />
     </dependencies>
   </metadata>

--- a/src/Cassette/packages.config
+++ b/src/Cassette/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AjaxMin" version="4.51.4507.18296" />
-  <package id="Iesi.Collections" version="3.2.0.4000" />
   <package id="Newtonsoft.Json" version="4.5.5" />
 </packages>


### PR DESCRIPTION
fix for #243. Use jQuery explicitly in global scope.
