### PR TITLE
Acknowledge origin of HasFlags() function

### DIFF
--- a/src/Cassette/Utilities/EnumT.cs
+++ b/src/Cassette/Utilities/EnumT.cs
@@ -21,6 +21,7 @@ namespace Cassette.Utilities
         /// <summary>
         /// Check to see if a flags enumeration has a specific flag set.
         /// </summary>
+        /// <remarks>Code based on http://stackoverflow.com/a/4108907 </remarks>
         /// <param name="variable">Flags enumeration to check</param>
         /// <param name="value">Flag to check for</param>
         public static bool HasFlag(this Enum variable, Enum value)


### PR DESCRIPTION
HasFlag appears to originate from http://stackoverflow.com/a/4108907
so provide correct acknowledgement in <remarks> comment.

Note: This _doesn't_ compile because of changes in the following commit 
which remove the HintPath condition:

https://github.com/andrewdavey/cassette/commit/a469658ef28e78948fa012177c6eaab2a4dfa4e7#src/Cassette/Cassette.csproj
