### PR TITLE
Fixed a number of nuget packaging issues in v2 beta1

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -87,6 +87,7 @@
             TaskDirectory="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v10.0\Web\" />
 
         <MakeDir Directories="$(OutputDir)"/>
+        <MakeDir Directories="$(PackageOutputDir)"/>
         <Exec Command="nuget pack src\%(NugetProject.Identity)\%(NugetProject.Identity).nuspec -symbols -Version $(Version) -OutputDirectory $(PackageOutputDir)"/>
     </Target>
 

--- a/src/Cassette.KnockoutJQueryTmpl/Cassette.KnockoutJQueryTmpl.nutrans
+++ b/src/Cassette.KnockoutJQueryTmpl/Cassette.KnockoutJQueryTmpl.nutrans
@@ -5,6 +5,7 @@
     <description xdt:Transform="Insert">KnockoutJS jQuery-tmpl HTML template compilation support for Cassette.</description>
     <dependencies xdt:Transform="Insert">
       <dependency id="Cassette" version="$version$" />
+      <dependency id="Cassette.JQueryTmpl" version="$version$" />
       <dependency id="Jurassic" version="2.1" />
     </dependencies>
   </metadata>

--- a/src/Cassette/Cassette.nutrans
+++ b/src/Cassette/Cassette.nutrans
@@ -4,7 +4,7 @@
     <id xdt:Transform="Insert">Cassette</id>
     <description xdt:Transform="Insert">Important: This is just the core library for Cassette. You probably want to install the Cassette.Aspnet package for ASP.NET support.</description>
     <dependencies xdt:Transform="Insert">
-      <dependency id="AjaxMin" version="4.46" />
+      <dependency id="AjaxMin" version="4.51" />
       <dependency id="Newtonsoft.Json" version="4.0" />
     </dependencies>
   </metadata>

--- a/src/Cassette/Cassette.nutrans
+++ b/src/Cassette/Cassette.nutrans
@@ -5,7 +5,7 @@
     <description xdt:Transform="Insert">Important: This is just the core library for Cassette. You probably want to install the Cassette.Aspnet package for ASP.NET support.</description>
     <dependencies xdt:Transform="Insert">
       <dependency id="AjaxMin" version="4.51" />
-      <dependency id="Newtonsoft.Json" version="4.0" />
+      <dependency id="Newtonsoft.Json" version="4.5" />
     </dependencies>
   </metadata>
   <files xdt:Transform="Insert">

--- a/src/Cassette/packages.config
+++ b/src/Cassette/packages.config
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AjaxMin" version="4.51.4507.18296" />
-  <package id="Iesi.Collections" version="3.2.0.4000" />
   <package id="Newtonsoft.Json" version="4.5.5" />
 </packages>


### PR DESCRIPTION
- build.xml now creates the nuget package directory if it does not exist, preventing errors the first time you run it.
- corrected AjaxMin and Json.NET dependencies version in Cassette.nutrans which caused runtime binding errors due to incorrect assembly redirects added by nuget.
- added missing package dependency between Cassette.KnockoutJQueryTempl and Cassette.JQueryTmpl
