### PR TITLE
InlineScriptBundle equality

### DIFF
--- a/src/Cassette.UnitTests/Cassette.UnitTests.csproj
+++ b/src/Cassette.UnitTests/Cassette.UnitTests.csproj
@@ -142,6 +142,7 @@
     <Compile Include="AssetDeserializer.cs" />
     <Compile Include="AssetReference.cs" />
     <Compile Include="AssetSerializer.cs" />
+    <Compile Include="Scripts\InlineScriptBundle.Equals.cs" />
     <Compile Include="Scripts\ExternalScriptBundleDeserializer.cs" />
     <Compile Include="Scripts\ScriptBundleDeserializer.cs" />
     <Compile Include="BundleSerializer.cs" />

--- a/src/Cassette.UnitTests/Scripts/InlineScriptBundle.Equals.cs
+++ b/src/Cassette.UnitTests/Scripts/InlineScriptBundle.Equals.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Should;
+using Xunit;
+
+namespace Cassette.Scripts
+{
+    public class InlineScriptBundleEqualityTests
+    {
+        [Fact]
+        public void TwoInstancesAreNotEqual() // refs #262
+        {
+            var bundle1 = new InlineScriptBundle("var x = 1;");
+            var bundle2 = new InlineScriptBundle("var x = 1;");
+
+            bundle1.Equals(bundle2).ShouldBeFalse();
+        }
+
+        [Fact]
+        public void TheSameInstanceIsEqual()
+        {
+            var bundle1 = new InlineScriptBundle("var x = 1;");
+
+            bundle1.Equals(bundle1).ShouldBeTrue();
+        }
+    }
+}

--- a/src/Cassette/Scripts/InlineScriptBundle.cs
+++ b/src/Cassette/Scripts/InlineScriptBundle.cs
@@ -2,6 +2,7 @@
 
 namespace Cassette.Scripts
 {
+#pragma warning disable 659
     class InlineScriptBundle : ScriptBundle
     {
         readonly string scriptContent;
@@ -27,5 +28,11 @@ namespace Cassette.Scripts
             var conditionalRenderer = new ConditionalRenderer();
             return conditionalRenderer.Render(Condition, html => html.Append(content));
         }
+
+        public override bool Equals(object obj)
+        {
+            return Object.ReferenceEquals(obj, this);
+        }
     }
+#pragma warning restore 659
 }


### PR DESCRIPTION
fix for #262. Inline scripts should be treated as unique. Possibly
they could base equality on their content but safer for now just to
use Object.ReferenceEquals.
