### PR TITLE
Fixed bug with the Hogan templating engine & partials.

### DIFF
--- a/src/Cassette/HtmlTemplates/RegisterTemplateWithHogan.cs
+++ b/src/Cassette/HtmlTemplates/RegisterTemplateWithHogan.cs
@@ -27,7 +27,7 @@ namespace Cassette.HtmlTemplates
 
                 sb.AppendLine("var " + javaScriptVariableName + " = " + javaScriptVariableName + "|| {};");
                 sb.AppendLine(template + "= new HoganTemplate();");
-                sb.AppendLine(template + ".render = " + compiled);
+                sb.AppendLine(template + ".r = " + compiled);
                 
                 return sb.ToString().AsStream();
             };


### PR DESCRIPTION
Hello,

Were using Hogan.js as our templating engine and cassette to precompile our templates and I've stumbled into a tiny bug with the way the templates are handled.

Previously, the compiled output of the template was set to the 'render' property of the HoganTemplate object. This was causing partial templates to render nothing. 

After some digging around in the Hogan source code, I found that the 'r' property of the HoganTemplates should be used instead of 'render'. To fix this, I just changed 'reder' to 'r'
