### PR TITLE
HttpModule needs precondition for IIS Classic mode to work

### DIFF
--- a/src/Cassette.Aspnet/Web.config.transform
+++ b/src/Cassette.Aspnet/Web.config.transform
@@ -13,7 +13,7 @@
             <add name="CassetteHttpModule" type="Cassette.Aspnet.CassetteHttpModule, Cassette.Aspnet" />
         </modules>
         <handlers>
-            <add name="CassetteHttpHandler" path="cassette.axd" verb="*" allowPathInfo="true" type="Cassette.Aspnet.CassetteHttpHandler, Cassette.Aspnet"/>
+            <add name="CassetteHttpHandler" path="cassette.axd" preCondition="integratedMode" verb="*" allowPathInfo="true" type="Cassette.Aspnet.CassetteHttpHandler, Cassette.Aspnet"/>
         </handlers>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
I added a precondition to the nuget web.config transform so Cassette works out of the box in an Classic mode Application Pool
