### PR TITLE
Fix for #267 - lock recursion exception

### DIFF
--- a/src/Cassette.UnitTests/BundleCollection.cs
+++ b/src/Cassette.UnitTests/BundleCollection.cs
@@ -90,5 +90,16 @@ namespace Cassette
 
             bundles["OTHER"].ShouldBeSameAs(bundle.Object);
         }
+
+        [Fact]
+        public void GivenWriteLockIsAlreadyHeld_GetWriteLockAllowsARecursiveLock() // refs #267
+        {
+            using(bundles.GetWriteLock())
+            {
+                using (bundles.GetWriteLock())
+                {
+                }
+            }
+        }
     }
 }

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -19,7 +19,7 @@ namespace Cassette
         readonly CassetteSettings settings;
         readonly IFileSearchProvider fileSearchProvider;
         readonly IBundleFactoryProvider bundleFactoryProvider;
-        readonly ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim();
+        readonly ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         Dictionary<Bundle, HashedSet<Bundle>> bundleImmediateReferences;
         Exception initializationException;
         


### PR DESCRIPTION
Previously, the BundleCollection.InitialisationException property was
attempting to acquire a recursive WriteLock (it had already been taken out
by DiagnosticRequestHandler.RebuildCache). The default behaviour of
ReaderWriterLockSlim is to reject the acquisition. This patch allows
recursive locks to be taken out, which fixes this problem generally.
