### PR TITLE
Added utility method for rebuilding the bundle cache.

### DIFF
--- a/src/Cassette.Aspnet/DiagnosticRequestHandler.cs
+++ b/src/Cassette.Aspnet/DiagnosticRequestHandler.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.Web;
 using System.Web.Routing;
 using System.Web.Script.Serialization;
-using Cassette.Caching;
 using Cassette.HtmlTemplates;
 using Cassette.Scripts;
 using Cassette.Stylesheets;
@@ -18,17 +17,15 @@ namespace Cassette.Aspnet
         readonly BundleCollection bundles;
         readonly CassetteSettings settings;
         readonly IUrlGenerator urlGenerator;
-        readonly IBundleCollectionCache cache;
-        readonly IBundleCollectionInitializer bundleCollectionInitializer;
+        readonly IBundleCacheRebuilder bundleCacheRebuilder;
 
-        public DiagnosticRequestHandler(RequestContext requestContext, BundleCollection bundles, CassetteSettings settings, IUrlGenerator urlGenerator, IBundleCollectionCache cache, IBundleCollectionInitializer bundleCollectionInitializer)
+        public DiagnosticRequestHandler(RequestContext requestContext, BundleCollection bundles, CassetteSettings settings, IUrlGenerator urlGenerator, IBundleCacheRebuilder bundleCacheRebuilder)
         {
             this.requestContext = requestContext;
             this.bundles = bundles;
             this.settings = settings;
             this.urlGenerator = urlGenerator;
-            this.cache = cache;
-            this.bundleCollectionInitializer = bundleCollectionInitializer;
+            this.bundleCacheRebuilder = bundleCacheRebuilder;
         }
 
         public void ProcessRequest()
@@ -67,17 +64,7 @@ namespace Cassette.Aspnet
         {
             if (requestContext.HttpContext.Request.Form["action"] == "rebuild-cache")
             {
-                RebuildCache();
-            }
-        }
-
-        void RebuildCache()
-        {
-            cache.Clear();
-            using (bundles.GetWriteLock())
-            {
-                bundles.Clear();
-                bundleCollectionInitializer.Initialize(bundles);
+                bundleCacheRebuilder.RebuildCache();
             }
         }
 

--- a/src/Cassette.Views.UnitTests/Bundles.cs
+++ b/src/Cassette.Views.UnitTests/Bundles.cs
@@ -24,7 +24,8 @@ namespace Cassette.Views
             settings = new CassetteSettings();
             bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
             fileAccessAuthorization = new Mock<IFileAccessAuthorization>();
-            Bundles.Helper = new BundlesHelper(bundles, settings, urlGenerator.Object, () => referenceBuilder.Object, fileAccessAuthorization.Object);
+            var bundleCacheRebuilder = new Mock<IBundleCacheRebuilder>();
+            Bundles.Helper = new BundlesHelper(bundles, settings, urlGenerator.Object, () => referenceBuilder.Object, fileAccessAuthorization.Object, bundleCacheRebuilder.Object);
         }
 
         [Fact]

--- a/src/Cassette.Views.UnitTests/Bundles_FileUrl_Tests.cs
+++ b/src/Cassette.Views.UnitTests/Bundles_FileUrl_Tests.cs
@@ -38,7 +38,8 @@ namespace Cassette.Views
 
             var referenceBuilder = new Mock<IReferenceBuilder>();
             var bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
-            Bundles.Helper = new BundlesHelper(bundles, settings, urlGenerator.Object, () => referenceBuilder.Object, fileAccessAuthorization.Object);
+            var bundleCacheRebuilder = new Mock<IBundleCacheRebuilder>();
+            Bundles.Helper = new BundlesHelper(bundles, settings, urlGenerator.Object, () => referenceBuilder.Object, fileAccessAuthorization.Object, bundleCacheRebuilder.Object);
         }
 
         [Fact]

--- a/src/Cassette.Views/Bundles.cs
+++ b/src/Cassette.Views/Bundles.cs
@@ -22,7 +22,7 @@ namespace Cassette.Views
         /// The helper implementation used by the static methods of this class.
         /// </summary>
         public static IBundlesHelper Helper { get; set; }
-
+        
         /// <summary>
         /// Adds a reference to a bundle for the current page.
         /// </summary>
@@ -347,6 +347,11 @@ namespace Cassette.Views
         public static string FileUrl(string applicationRelativeFilePath)
         {
             return Helper.FileUrl(applicationRelativeFilePath);
+        }
+
+        public static void RebuidCache()
+        {
+            Helper.RebuildBundleCache();
         }
     }
 }

--- a/src/Cassette.Views/BundlesHelper.cs
+++ b/src/Cassette.Views/BundlesHelper.cs
@@ -21,14 +21,16 @@ namespace Cassette.Views
         readonly IUrlGenerator urlGenerator;
         readonly Func<IReferenceBuilder> getReferenceBuilder;
         readonly IFileAccessAuthorization fileAccessAuthorization;
+        readonly IBundleCacheRebuilder bundleCacheRebuilder;
 
-        public BundlesHelper(BundleCollection bundles, CassetteSettings settings, IUrlGenerator urlGenerator, Func<IReferenceBuilder> getReferenceBuilder, IFileAccessAuthorization fileAccessAuthorization)
+        public BundlesHelper(BundleCollection bundles, CassetteSettings settings, IUrlGenerator urlGenerator, Func<IReferenceBuilder> getReferenceBuilder, IFileAccessAuthorization fileAccessAuthorization, IBundleCacheRebuilder bundleCacheRebuilder)
         {
             this.bundles = bundles;
             this.settings = settings;
             this.urlGenerator = urlGenerator;
             this.getReferenceBuilder = getReferenceBuilder;
             this.fileAccessAuthorization = fileAccessAuthorization;
+            this.bundleCacheRebuilder = bundleCacheRebuilder;
         }
 
         void IStartUpTask.Start()
@@ -132,6 +134,11 @@ namespace Cassette.Views
                 var hash = stream.ComputeSHA1Hash().ToHexString();
                 return urlGenerator.CreateRawFileUrl(applicationRelativeFilePath, hash);
             }
+        }
+
+        public void RebuildBundleCache()
+        {
+            bundleCacheRebuilder.RebuildCache();
         }
 
         void ThrowIfCannotRequestRawFile(string applicationRelativeFilePath, IFile file)

--- a/src/Cassette.Views/IBundlesHelper.cs
+++ b/src/Cassette.Views/IBundlesHelper.cs
@@ -23,5 +23,7 @@ namespace Cassette.Views
             where T : Bundle;
 
         string FileUrl(string applicationRelativeFilePath);
+
+        void RebuildBundleCache();
     }
 }

--- a/src/Cassette/BundleCacheRebuilder.cs
+++ b/src/Cassette/BundleCacheRebuilder.cs
@@ -1,0 +1,33 @@
+﻿using Cassette.Caching;
+
+namespace Cassette
+{
+    public interface IBundleCacheRebuilder
+    {
+        void RebuildCache();
+    }
+
+    class BundleCacheRebuilder : IBundleCacheRebuilder
+    {
+        readonly BundleCollection bundles;
+        readonly IBundleCollectionCache cache;
+        readonly IBundleCollectionInitializer bundleCollectionInitializer;
+
+        BundleCacheRebuilder(BundleCollection bundles, IBundleCollectionCache cache, IBundleCollectionInitializer bundleCollectionInitializer)
+        {
+            this.bundles = bundles;
+            this.cache = cache;
+            this.bundleCollectionInitializer = bundleCollectionInitializer;
+        }
+
+        public void RebuildCache()
+        {
+            cache.Clear();
+            using (bundles.GetWriteLock())
+            {
+                bundles.Clear();
+                bundleCollectionInitializer.Initialize(bundles);
+            }
+        }
+    }
+}

--- a/src/Cassette/BundleCacheRebuilder.cs
+++ b/src/Cassette/BundleCacheRebuilder.cs
@@ -13,7 +13,7 @@ namespace Cassette
         readonly IBundleCollectionCache cache;
         readonly IBundleCollectionInitializer bundleCollectionInitializer;
 
-        BundleCacheRebuilder(BundleCollection bundles, IBundleCollectionCache cache, IBundleCollectionInitializer bundleCollectionInitializer)
+        public BundleCacheRebuilder(BundleCollection bundles, IBundleCollectionCache cache, IBundleCollectionInitializer bundleCollectionInitializer)
         {
             this.bundles = bundles;
             this.cache = cache;

--- a/src/Cassette/Cassette.csproj
+++ b/src/Cassette/Cassette.csproj
@@ -79,6 +79,7 @@
     </Compile>
     <Compile Include="AssemblyScanner.cs" />
     <Compile Include="AssetPathComparer.cs" />
+    <Compile Include="BundleCacheRebuilder.cs" />
     <Compile Include="Caching\BundleCollectionCache.cs" />
     <Compile Include="Caching\BundleCollectionCacheReader.cs" />
     <Compile Include="Caching\ManifestValidator.cs" />

--- a/src/Cassette/HostBase.cs
+++ b/src/Cassette/HostBase.cs
@@ -126,6 +126,8 @@ namespace Cassette
                 var sourceDirectory = c.Resolve<CassetteSettings>().SourceDirectory;
                 return new FileAssetCacheValidator(sourceDirectory);
             });
+
+            container.Register(typeof(IBundleCacheRebuilder), typeof(BundleCacheRebuilder));
         }
 
         static readonly Dictionary<string, Type> BundleDeserializers = new Dictionary<string, Type>


### PR DESCRIPTION
Factored out the bundle cache rebuilding from DiagnosticRequestHandler
into a new class BundleCacheRebuilder. This can be invoked by consumers by
calling Bundles.RebuildCache();
