### PR TITLE
Changed ConstantHtmlRender (Potentially Fixed Bug)

### DIFF
--- a/src/Cassette/ConstantHtmlRenderer.cs
+++ b/src/Cassette/ConstantHtmlRenderer.cs
@@ -16,11 +16,7 @@ namespace Cassette
 
         public string Render(T bundle)
         {
-            return Regex.Replace(
-                html,
-                "<CASSETTE_URL_ROOT>(.*?)</CASSETTE_URL_ROOT>",
-                match => urlModifier.Modify(match.Groups[1].Value)
-            );
+            return Regex.Replace(html, "([^\"]+_cassette[^\"]+)\"", match => urlModifier.Modify(match.Captures[0].Value));
         }
     }
 }


### PR DESCRIPTION
I Changed the regular expression in the constanthtmlrenderer.render
method so that it calls render on every pageload. Therefore one can 
dynamically change the url modifier using the iurlmodifier in
CassetteConfiguration without rebuilding the project.
