### PR TITLE
FileSystemWatchingBundleRebuilder now makes a readonly copy of the bundl...

### DIFF
--- a/src/Cassette/FileSystemWatchingBundleRebuilder.cs
+++ b/src/Cassette/FileSystemWatchingBundleRebuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
 using Cassette.IO;
@@ -35,7 +36,7 @@ namespace Cassette
             bundleDescriptorFilenames = GetBundleDescriptorFilenames();
 
             // Initially use the bundles collection, but this will get updated in the Changed event handler.
-            readOnlyBundles = bundles;
+            readOnlyBundles = new ReadOnlyCollection<Bundle>(bundles.ToList());
             bundles.Changed += HandleBundlesChanged;
         }
 


### PR DESCRIPTION
FileSystemWatchingBundleRebuilder now makes a readonly copy of the bundle collection, preventing occasional threading issues on startup. The error we were seeing is

```
Unhandled Exception: System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
at System.Collections.Generic.List`1.Enumerator.MoveNextRare()
at System.Collections.Generic.List`1.Enumerator.MoveNext()
at Cassette.BundleEnumerableExtensions.Accept(IEnumerable`1 bundles, IBundleVisitor bundleVisitor)
at Cassette.FileSystemWatchingBundleRebuilder.AnyBundleContainsPath(String path)
at Cassette.FileSystemWatchingBundleRebuilder.IsKnownPath(String path)
at Cassette.FileSystemWatchingBundleRebuilder.HandleChanged(String path)
at Cassette.IO.FileSystemDirectory.<>c__DisplayClass6.<WatchForChanges>b__4(Object s, FileSystemEventArgs e)
at System.IO.FileSystemWatcher.OnChanged(FileSystemEventArgs e)
at System.IO.FileSystemWatcher.NotifyFileSystemEventArgs(Int32 action, String name)
at System.IO.FileSystemWatcher.CompletionStatusChanged(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* overlappedPointer)
at System.Threading._IOCompletionCallback.PerformIOCompletionCallback(UInt32 errorCode, UInt32 numBytes, NativeOverlapped* pOVERLAP)
```
