### PR TITLE
Fix for duplicate resource references when there are interdependencies between different bundle types

### DIFF
--- a/src/Cassette.IntegrationTests/Cassette.IntegrationTests.csproj
+++ b/src/Cassette.IntegrationTests/Cassette.IntegrationTests.csproj
@@ -162,6 +162,10 @@
       <Project>{C9A552DA-83EB-4479-BAB6-C40B6091E3D4}</Project>
       <Name>Cassette.CoffeeScript</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Cassette.KnockoutJQueryTmpl\Cassette.KnockoutJQueryTmpl.csproj">
+      <Project>{C38D3ED4-367B-42E6-97A3-B8403DB528FF}</Project>
+      <Name>Cassette.KnockoutJQueryTmpl</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Cassette.Less\Cassette.Less.csproj">
       <Project>{EC1BE4F4-A2A7-4154-9F4D-F75D1B1FD976}</Project>
       <Name>Cassette.Less</Name>

--- a/src/Cassette.IntegrationTests/assets/templates/asset-1.htm
+++ b/src/Cassette.IntegrationTests/assets/templates/asset-1.htm
@@ -1,1 +1,5 @@
-﻿<p>asset 1</p>
+﻿<!--
+    @reference ~/scripts/bundle-a
+    -->
+
+<p>asset 1</p>

--- a/src/Cassette.UnitTests/BundleCollection.IncludeReferencesAndSortBundles.cs
+++ b/src/Cassette.UnitTests/BundleCollection.IncludeReferencesAndSortBundles.cs
@@ -159,6 +159,27 @@ namespace Cassette
             });
         }
 
+        [Fact]
+        public void WhenInterdependenciesBetweenBundlesOfDifferentType_DoesNotDuplicateBundles()
+        {
+            var bundleA = new ScriptBundle("~/a");
+            var bundleB = new StylesheetBundle("~/b");
+            var bundleC = new TestableBundle("~/c");
+            bundleC.AddReference("~/a");
+
+            var bundles = new Bundle[] { bundleA, bundleB, bundleC };
+            var collection = CreateBundleCollection(bundles);
+            collection.BuildReferences();
+            var sorted = collection.IncludeReferencesAndSortBundles(bundles).ToArray();
+
+            sorted.ShouldEqual(new Bundle[]
+            {
+                bundleB,
+                bundleA,
+                bundleC 
+            });
+        }
+
         BundleCollection CreateBundleCollection(IEnumerable<Bundle> bundles)
         {
             var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());

--- a/src/Cassette.UnitTests/HtmlTemplates/HtmlTemplateBundle.cs
+++ b/src/Cassette.UnitTests/HtmlTemplates/HtmlTemplateBundle.cs
@@ -41,6 +41,14 @@ namespace Cassette.HtmlTemplates
         }
 
         [Fact]
+        public void GetTemplateIdReturnsAssetFilenameWithoutExtension_WhenTemplateBundlePerFile()
+        {
+            var bundle = new HtmlTemplateBundle("~/test.htm");
+            var id = bundle.GetTemplateId(new StubAsset("~/test.htm"));
+            id.ShouldEqual("test");
+        }
+
+        [Fact]
         public void GetTemplateIdIncludesDirectoryAndFilenameSeparatedWithHyphen()
         {
             var bundle = new HtmlTemplateBundle("~");

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -742,16 +742,10 @@ namespace Cassette
                 throw new InvalidOperationException("BuildReferences must be called once before IncludeReferencesAndSortBundles can be called.");
             }
 
-            var partitioned = PartitionByBaseType(bundlesToSort);
-            var sortedPartitions = partitioned.Select(bundlesOfSameType =>
-            {
-                var bundlesArray = bundlesOfSameType.ToArray();
-                var all = GetAllRequiredBundles(bundlesArray);
-                var graph = BuildBundleGraph(bundleImmediateReferences, all);
-                return graph.TopologicalSort();
-            });
-
-            return sortedPartitions.Aggregate(Enumerable.Empty<Bundle>(), (a, b) => a.Concat(b));
+            var all = GetAllRequiredBundles(bundlesToSort);
+            var partitioned = PartitionByBaseType(all).SelectMany(b => b).ToArray();
+            var graph = BuildBundleGraph(bundleImmediateReferences, partitioned);
+            return graph.TopologicalSort();
         }
 
         IEnumerable<IEnumerable<Bundle>> PartitionByBaseType(IEnumerable<Bundle> bundlesToSort)

--- a/src/Cassette/HtmlTemplates/HtmlTemplateBundle.cs
+++ b/src/Cassette/HtmlTemplates/HtmlTemplateBundle.cs
@@ -35,7 +35,7 @@ namespace Cassette.HtmlTemplates
         internal string GetTemplateId(IAsset asset)
         {
             string id;
-            if (asset.Path.StartsWith(Path, StringComparison.OrdinalIgnoreCase))
+            if (asset.Path.StartsWith(Path, StringComparison.OrdinalIgnoreCase) && !asset.Path.Equals(Path, StringComparison.OrdinalIgnoreCase))
             {
                 id = asset.Path
                     .Substring(Path.Length + 1)


### PR DESCRIPTION
This situation occurs when you have e.g. a Knockout template which references script or stylesheet bundles. Previously, the scripts / stylesheets where getting included multiple times on the page because the BundleCollection was only resolving the dependency graph within the scope of the base type of the bundle. 

This commit resolves dependencies between all base types and preserves the existing behaviour of grouping bundles by type generally.

It also includes a minor fix to HtmlTemplateBundle to support the test case where you have a template bundle based on a per-file strategy.
