### PR TITLE
JST array for templates

### DIFF
--- a/src/Cassette/Cassette.csproj
+++ b/src/Cassette/Cassette.csproj
@@ -100,6 +100,7 @@
     <Compile Include="BundleCollection.cs" />
     <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptTransformers.cs" />
     <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptArrayTransformers.cs" />
+    <Compile Include="HtmlTemplates\WrapJavaScriptArrayHtmlTemplatesTransformer.cs" />
     <Compile Include="HtmlTemplates\WrapJavaScriptArrayHtmlTemplates.cs" />
     <Compile Include="HtmlTemplates\JavaScriptArrayHtmlTemplatePipeline.cs" />
     <Compile Include="HtmlTemplates\HtmlTemplateBundleExtensions.cs" />

--- a/src/Cassette/Cassette.csproj
+++ b/src/Cassette/Cassette.csproj
@@ -99,6 +99,7 @@
     <Compile Include="HostBase.cs" />
     <Compile Include="BundleCollection.cs" />
     <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptTransformers.cs" />
+    <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptArrayTransformers.cs" />
     <Compile Include="HtmlTemplates\JavaScriptArrayHtmlTemplatePipeline.cs" />
     <Compile Include="HtmlTemplates\HtmlTemplateBundleExtensions.cs" />
     <Compile Include="HtmlTemplates\WrapJavaScriptHtmlTemplates.cs" />

--- a/src/Cassette/Cassette.csproj
+++ b/src/Cassette/Cassette.csproj
@@ -99,6 +99,7 @@
     <Compile Include="HostBase.cs" />
     <Compile Include="BundleCollection.cs" />
     <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptTransformers.cs" />
+    <Compile Include="HtmlTemplates\JavaScriptArrayHtmlTemplatePipeline.cs" />
     <Compile Include="HtmlTemplates\HtmlTemplateBundleExtensions.cs" />
     <Compile Include="HtmlTemplates\WrapJavaScriptHtmlTemplates.cs" />
     <Compile Include="HtmlTemplates\IHtmlTemplateIdStrategy.cs" />

--- a/src/Cassette/Cassette.csproj
+++ b/src/Cassette/Cassette.csproj
@@ -100,6 +100,7 @@
     <Compile Include="BundleCollection.cs" />
     <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptTransformers.cs" />
     <Compile Include="HtmlTemplates\AddHtmlTemplateToJavaScriptArrayTransformers.cs" />
+    <Compile Include="HtmlTemplates\WrapJavaScriptArrayHtmlTemplates.cs" />
     <Compile Include="HtmlTemplates\JavaScriptArrayHtmlTemplatePipeline.cs" />
     <Compile Include="HtmlTemplates\HtmlTemplateBundleExtensions.cs" />
     <Compile Include="HtmlTemplates\WrapJavaScriptHtmlTemplates.cs" />

--- a/src/Cassette/HtmlTemplates/AddHtmlTemplateToJavaScriptArrayTransformers.cs
+++ b/src/Cassette/HtmlTemplates/AddHtmlTemplateToJavaScriptArrayTransformers.cs
@@ -1,0 +1,28 @@
+using Cassette.BundleProcessing;
+
+namespace Cassette.HtmlTemplates
+{
+    public class AddHtmlTemplateToJavaScriptArrayTransformers : IBundleProcessor<HtmlTemplateBundle>
+    {
+        readonly HtmlTemplateToJavaScriptTransformer.Factory createTransformer;
+        readonly string variableName;
+
+        public AddHtmlTemplateToJavaScriptArrayTransformers(HtmlTemplateToJavaScriptTransformer.Factory createTransformer, string variableName)
+        {
+            if (string.IsNullOrEmpty(variableName))
+                variableName = "JST";
+
+            this.createTransformer = createTransformer;
+            this.variableName = variableName;
+        }
+
+        public void Process(HtmlTemplateBundle bundle)
+        {
+            var transformer = createTransformer(this.variableName + "[{0}]={1};", bundle);
+            foreach (var asset in bundle.Assets)
+            {
+                asset.AddAssetTransformer(transformer);
+            }
+        }
+    }
+}

--- a/src/Cassette/HtmlTemplates/AddHtmlTemplateToJavaScriptArrayTransformers.cs
+++ b/src/Cassette/HtmlTemplates/AddHtmlTemplateToJavaScriptArrayTransformers.cs
@@ -5,20 +5,27 @@ namespace Cassette.HtmlTemplates
     public class AddHtmlTemplateToJavaScriptArrayTransformers : IBundleProcessor<HtmlTemplateBundle>
     {
         readonly HtmlTemplateToJavaScriptTransformer.Factory createTransformer;
-        readonly string variableName;
 
-        public AddHtmlTemplateToJavaScriptArrayTransformers(HtmlTemplateToJavaScriptTransformer.Factory createTransformer, string variableName)
+        /// <summary>
+        /// The name of the JavaScript variable to store compiled templates in.
+        /// For example, the default is "JST", so a template will be registered as <code>JST['my-template'] = ...;</code>.
+        /// </summary>
+        public string JavaScriptVariableName { get; set; }
+
+        public AddHtmlTemplateToJavaScriptArrayTransformers(HtmlTemplateToJavaScriptTransformer.Factory createTransformer)
         {
-            if (string.IsNullOrEmpty(variableName))
-                variableName = "JST";
-
             this.createTransformer = createTransformer;
-            this.variableName = variableName;
         }
 
         public void Process(HtmlTemplateBundle bundle)
         {
-            var transformer = createTransformer(this.variableName + "[{0}]={1};", bundle);
+            var javaScriptVariableName = JavaScriptVariableName;
+            if(string.IsNullOrEmpty(javaScriptVariableName))
+            {
+                javaScriptVariableName = "JST";
+            }
+
+            var transformer = createTransformer(javaScriptVariableName + "[{0}]={1};", bundle);
             foreach (var asset in bundle.Assets)
             {
                 asset.AddAssetTransformer(transformer);

--- a/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
+++ b/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
@@ -31,7 +31,7 @@ namespace Cassette.HtmlTemplates
 
         void TransformHtmlTemplatesIntoJavaScript()
         {
-            Add<AddHtmlTemplateToJavaScriptTransformers>();
+            Add<AddHtmlTemplateToJavaScriptArrayTransformers>();
         }
 
         void Concatenate()

--- a/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
+++ b/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
@@ -9,12 +9,27 @@ namespace Cassette.HtmlTemplates
     {
         readonly TinyIoCContainer container;
         readonly CassetteSettings settings;
+        readonly string javaScriptVariableName;
+        readonly AddHtmlTemplateToJavaScriptArrayTransformers transformer;
 
         public JavaScriptArrayHtmlTemplatePipeline(TinyIoCContainer container, CassetteSettings settings)
+            : this(container, settings, "JST")
+        {
+        }
+
+        public JavaScriptArrayHtmlTemplatePipeline(TinyIoCContainer container, CassetteSettings settings, string javascriptVariableName)
             : base(container)
         {
+            if (string.IsNullOrEmpty(javascriptVariableName))
+            {
+                throw new ArgumentNullException("javascriptVariableName");
+            }
+
             this.container = container;
             this.settings = settings;
+            this.javaScriptVariableName = javascriptVariableName;
+            this.transformer = container.Resolve<AddHtmlTemplateToJavaScriptArrayTransformers>();
+
             BuildPipeline();
         }
 
@@ -31,7 +46,8 @@ namespace Cassette.HtmlTemplates
 
         void TransformHtmlTemplatesIntoJavaScript()
         {
-            Add<AddHtmlTemplateToJavaScriptArrayTransformers>();
+            transformer.JavaScriptVariableName = javaScriptVariableName;
+            Add(transformer);
         }
 
         void Concatenate()
@@ -41,7 +57,7 @@ namespace Cassette.HtmlTemplates
 
         void WrapJavaScriptHtmlTemplates()
         {
-            Add(new WrapJavaScriptArrayHtmlTemplates());
+            Add(new WrapJavaScriptArrayHtmlTemplates(javaScriptVariableName));
         }
 
         void MinifyIfNotDebugging()

--- a/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
+++ b/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
@@ -41,7 +41,7 @@ namespace Cassette.HtmlTemplates
 
         void WrapJavaScriptHtmlTemplates()
         {
-            Add(new WrapJavaScriptHtmlTemplates());
+            Add(new WrapJavaScriptArrayHtmlTemplates());
         }
 
         void MinifyIfNotDebugging()

--- a/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
+++ b/src/Cassette/HtmlTemplates/JavaScriptArrayHtmlTemplatePipeline.cs
@@ -1,0 +1,70 @@
+using System;
+using Cassette.BundleProcessing;
+using Cassette.Scripts;
+using Cassette.TinyIoC;
+
+namespace Cassette.HtmlTemplates
+{
+    public class JavaScriptArrayHtmlTemplatePipeline : BundlePipeline<HtmlTemplateBundle>
+    {
+        readonly TinyIoCContainer container;
+        readonly CassetteSettings settings;
+
+        public JavaScriptArrayHtmlTemplatePipeline(TinyIoCContainer container, CassetteSettings settings)
+            : base(container)
+        {
+            this.container = container;
+            this.settings = settings;
+            BuildPipeline();
+        }
+
+        void BuildPipeline()
+        {
+            TransformHtmlTemplatesIntoJavaScript();
+            Concatenate();
+            WrapJavaScriptHtmlTemplates();
+            MinifyIfNotDebugging();
+            AssignContentType();
+            AssignHash();
+            AssignRenderer();
+        }
+
+        void TransformHtmlTemplatesIntoJavaScript()
+        {
+            Add<AddHtmlTemplateToJavaScriptTransformers>();
+        }
+
+        void Concatenate()
+        {
+            Add(new ConcatenateAssets { Separator = Environment.NewLine });
+        }
+
+        void WrapJavaScriptHtmlTemplates()
+        {
+            Add(new WrapJavaScriptHtmlTemplates());
+        }
+
+        void MinifyIfNotDebugging()
+        {
+            if (!settings.IsDebuggingEnabled)
+            {
+                Add(new MinifyAssets(container.Resolve<IJavaScriptMinifier>()));
+            }
+        }
+
+        void AssignContentType()
+        {
+            Add(new AssignContentType("text/javascript"));
+        }
+
+        void AssignHash()
+        {
+            Add(new AssignHash());
+        }
+
+        void AssignRenderer()
+        {
+            Add(new AssignHtmlTemplateRenderer(container.Resolve<RemoteHtmlTemplateBundleRenderer>()));
+        }
+    }
+}

--- a/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplates.cs
+++ b/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplates.cs
@@ -1,0 +1,17 @@
+using System;
+using Cassette.BundleProcessing;
+
+namespace Cassette.HtmlTemplates
+{
+    public class WrapJavaScriptArrayHtmlTemplates : IBundleProcessor<HtmlTemplateBundle>
+    {
+        public void Process(HtmlTemplateBundle bundle)
+        {
+            if (bundle.Assets.Count == 0) return;
+            if (bundle.Assets.Count > 1) throw new ArgumentException("WrapJavaScriptArrayHtmlTemplates should only process a bundle where the assets have been concatenated.", "bundle");
+
+            var transformer = new WrapJavaScriptHtmlTemplatesTransformer(bundle.ContentType);
+            bundle.Assets[0].AddAssetTransformer(transformer);
+        }
+    }
+}

--- a/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplates.cs
+++ b/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplates.cs
@@ -5,12 +5,24 @@ namespace Cassette.HtmlTemplates
 {
     public class WrapJavaScriptArrayHtmlTemplates : IBundleProcessor<HtmlTemplateBundle>
     {
+        readonly string javaScriptVariableName;
+
+        public WrapJavaScriptArrayHtmlTemplates(string javaScriptVariableName)
+        {
+            if (string.IsNullOrEmpty(javaScriptVariableName))
+            {
+                javaScriptVariableName = "JST";
+            }
+
+            this.javaScriptVariableName = javaScriptVariableName;
+        }
+
         public void Process(HtmlTemplateBundle bundle)
         {
             if (bundle.Assets.Count == 0) return;
             if (bundle.Assets.Count > 1) throw new ArgumentException("WrapJavaScriptArrayHtmlTemplates should only process a bundle where the assets have been concatenated.", "bundle");
 
-            var transformer = new WrapJavaScriptArrayHtmlTemplatesTransformer(bundle.ContentType);
+            var transformer = new WrapJavaScriptArrayHtmlTemplatesTransformer(javaScriptVariableName);
             bundle.Assets[0].AddAssetTransformer(transformer);
         }
     }

--- a/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplates.cs
+++ b/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplates.cs
@@ -10,7 +10,7 @@ namespace Cassette.HtmlTemplates
             if (bundle.Assets.Count == 0) return;
             if (bundle.Assets.Count > 1) throw new ArgumentException("WrapJavaScriptArrayHtmlTemplates should only process a bundle where the assets have been concatenated.", "bundle");
 
-            var transformer = new WrapJavaScriptHtmlTemplatesTransformer(bundle.ContentType);
+            var transformer = new WrapJavaScriptArrayHtmlTemplatesTransformer(bundle.ContentType);
             bundle.Assets[0].AddAssetTransformer(transformer);
         }
     }

--- a/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplatesTransformer.cs
+++ b/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplatesTransformer.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Text;
+using Cassette.Utilities;
+
+namespace Cassette.HtmlTemplates
+{
+    public class WrapJavaScriptArrayHtmlTemplatesTransformer : IAssetTransformer
+    {
+        readonly string contentType;
+
+        public WrapJavaScriptArrayHtmlTemplatesTransformer(string contentType)
+        {
+            this.contentType = contentType;
+        }
+
+        public Func<Stream> Transform(Func<Stream> openSourceStream, IAsset asset)
+        {
+            return () =>
+            {
+                var addTemplateCalls = openSourceStream().ReadToEnd();
+
+                var output = string.Format(
+                    @"(function(d) {{
+var addTemplate = function(id, content) {{
+    var script = d.createElement('script');
+    script.type = '{0}';
+    script.id = id;
+    if (typeof script.textContent !== 'undefined') {{
+        script.textContent = content;
+    }} else {{
+        script.innerText = content;
+    }}
+    var x = d.getElementsByTagName('script')[0];
+    x.parentNode.insertBefore(script, x);
+}};
+{1}
+}}(document));",
+                    contentType,
+                    addTemplateCalls);
+
+                return new MemoryStream(Encoding.UTF8.GetBytes(output));
+            };
+        }
+    }
+}

--- a/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplatesTransformer.cs
+++ b/src/Cassette/HtmlTemplates/WrapJavaScriptArrayHtmlTemplatesTransformer.cs
@@ -26,7 +26,8 @@ namespace Cassette.HtmlTemplates
                 
                 var addTemplateCalls = openSourceStream().ReadToEnd();
 
-                var output = string.Format(@"window.{0}=window.{0} || {{}};{1}", javascriptVariableName, addTemplateCalls);
+                var output = string.Format(@"window.{0}=window.{0} || {{}};
+{1}", javascriptVariableName, addTemplateCalls);
 
                 return new MemoryStream(Encoding.UTF8.GetBytes(output));
             };


### PR DESCRIPTION
PR for #265

Introduces new classes main one being `JavaScriptArrayHtmlTemplatePipeline`.

``` c#
bundles.Add<HtmlTemplateBundle>("assets/templates",
                b => b.Pipeline = new JavaScriptArrayHtmlTemplatePipeline(this.container, this.settings));
```

output:

``` js
window.JST=window.JST || {};
JST["todo/index"]="<div id=\"todo-container\">\r\n    Todo\r\n</div>";
JST["todo/item"]="<div id=\"todo-item\">\r\n    item\r\n</div>";
```

If you want to change the variable to something else besides `JST` pass the third parameter.

``` c#
 new JavaScriptArrayHtmlTemplatePipeline(this.container, this.settings, "templateHashName")
```

Here is an example at how clients can cache the underscore templates.

``` js
    function buildTemplate(model) {
        var template = JST[this.templateName];
        if (typeof (template) === 'string') {
            template = JST[this.templateName] = _.template(template);
        }

        return template(model);
    }
```
