### PR TITLE
Adding MaxAge to the Cache-Control header

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -111,6 +111,14 @@ namespace Cassette.Aspnet
         }
 
         [Fact]
+        public void MaxAgeIsSetToOneYear()
+        {
+            // Setting the cache to Public, then the MaxAge will be set on the asset.
+            responseCache.Verify(c => c.SetCacheability(HttpCacheability.Public));
+            responseCache.Verify(c => c.SetMaxAge(It.Is<TimeSpan>(t => t.TotalDays >= 365)));
+        }
+
+        [Fact]
         public void ResponseIsPubliclyCacheable()
         {
             responseCache.Verify(c => c.SetCacheability(HttpCacheability.Public));

--- a/src/Cassette.Aspnet/AssetRequestHandler.cs
+++ b/src/Cassette.Aspnet/AssetRequestHandler.cs
@@ -2,6 +2,7 @@
 using System.Web.Routing;
 using Cassette.Utilities;
 using Trace = Cassette.Diagnostics.Trace;
+using System;
 
 namespace Cassette.Aspnet
 {
@@ -42,8 +43,7 @@ namespace Cassette.Aspnet
             response.ContentType = bundle.ContentType;
 
             var actualETag = "\"" + asset.Hash.ToHexString() + "\"";
-            response.Cache.SetCacheability(HttpCacheability.Public);
-            response.Cache.SetETag(actualETag);
+            CacheLongTime(response, actualETag);
 
             var givenETag = request.Headers["If-None-Match"];
             if (givenETag == actualETag)
@@ -57,6 +57,14 @@ namespace Cassette.Aspnet
                     stream.CopyTo(response.OutputStream);
                 }
             }
+        }
+
+        void CacheLongTime(HttpResponseBase response, string actualETag)
+        {
+            response.Cache.SetCacheability(HttpCacheability.Public);
+            response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
+            response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
+            response.Cache.SetETag(actualETag);
         }
 
         void SendNotModified(HttpResponseBase response)

--- a/src/Cassette.Aspnet/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet/BundleRequestHandler.cs
@@ -84,6 +84,7 @@ namespace Cassette.Aspnet
         {
             response.Cache.SetCacheability(HttpCacheability.Public);
             response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
+            response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
             response.Cache.SetETag(actualETag);
         }
 

--- a/src/Cassette.Aspnet/CachedFileRequestHandler.cs
+++ b/src/Cassette.Aspnet/CachedFileRequestHandler.cs
@@ -44,7 +44,9 @@ namespace Cassette.Aspnet
         {
             using (var stream = file.OpenRead())
             {
+                response.Cache.SetCacheability(HttpCacheability.Public);
                 response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
+                response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
                 stream.CopyTo(response.OutputStream);
             }
         }

--- a/src/Cassette.Aspnet/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet/RawFileRequestRewriter.cs
@@ -96,6 +96,7 @@ namespace Cassette.Aspnet
         void SetFarFutureExpiresHeader()
         {
             context.Response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
+            context.Response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
         }
     }
 }


### PR DESCRIPTION
Adding MaxAge to be 365 days on the Cache-Control header tells the
browser that this resource will not change in 365 days, so it doesn't
have to check with the server for any changes.  This has a significant
impact on mobile devices where the 304 round trip latency could be high.
