### PR TITLE
Partial implementation of RFC 2616.  Fixes #340

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -220,13 +220,13 @@ namespace Cassette.Aspnet
         }
 
         [Fact]
-        public void ResponseFilterIsDeflateStream()
+        public void ResponseFilterIsGZipStream()
         {
             response.VerifySet(r => r.Filter = It.IsAny<GZipStream>());
         }
 
         [Fact]
-        public void ContentEncodingHeaderIsDeflate()
+        public void ContentEncodingHeaderIsGzip()
         {
             response.Verify(r => r.AppendHeader("Content-Encoding", "gzip"));
         }

--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -270,6 +270,38 @@ namespace Cassette.Aspnet
         }
     }
 
+    public class GivenRequestMultipleEncodingsEquivalentQValues_WhenProcessRequest : BundleRequestHandler_Tests
+    {
+        public GivenRequestMultipleEncodingsEquivalentQValues_WhenProcessRequest()
+        {
+            requestHeaders.Add("Accept-Encoding", "gzip;q=1.0, deflate;q=1.0");
+            response.SetupGet(r => r.Filter).Returns(Stream.Null);
+
+            SetupTestBundle();
+
+            var handler = CreateRequestHandler();
+            handler.ProcessRequest("~/test");
+        }
+
+        [Fact]
+        public void ResponseFilterIsGZipStream()
+        {
+            response.VerifySet(r => r.Filter = It.IsAny<GZipStream>());
+        }
+
+        [Fact]
+        public void ContentEncodingHeaderIsGzip()
+        {
+            response.Verify(r => r.AppendHeader("Content-Encoding", "gzip"));
+        }
+
+        [Fact]
+        public void VeryHeaderIsAcceptEncoding()
+        {
+            response.Verify(r => r.AppendHeader("Vary", "Accept-Encoding"));
+        }
+    }
+
     public class GivenRequestWithUnrecognizedEncoding_WhenProcessRequest : BundleRequestHandler_Tests
     {
         public GivenRequestWithUnrecognizedEncoding_WhenProcessRequest()

--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -238,6 +238,38 @@ namespace Cassette.Aspnet
         }
     }
 
+    public class GivenRequestMultipleEncodingsNoQValue_WhenProcessRequest : BundleRequestHandler_Tests
+    {
+        public GivenRequestMultipleEncodingsNoQValue_WhenProcessRequest()
+        {
+            requestHeaders.Add("Accept-Encoding", "gzip,deflate");
+            response.SetupGet(r => r.Filter).Returns(Stream.Null);
+
+            SetupTestBundle();
+
+            var handler = CreateRequestHandler();
+            handler.ProcessRequest("~/test");
+        }
+
+        [Fact]
+        public void ResponseFilterIsGZipStream()
+        {
+            response.VerifySet(r => r.Filter = It.IsAny<GZipStream>());
+        }
+
+        [Fact]
+        public void ContentEncodingHeaderIsGzip()
+        {
+            response.Verify(r => r.AppendHeader("Content-Encoding", "gzip"));
+        }
+
+        [Fact]
+        public void VeryHeaderIsAcceptEncoding()
+        {
+            response.Verify(r => r.AppendHeader("Vary", "Accept-Encoding"));
+        }
+    }
+
     public class GivenRequestWithUnrecognizedEncoding_WhenProcessRequest : BundleRequestHandler_Tests
     {
         public GivenRequestWithUnrecognizedEncoding_WhenProcessRequest()

--- a/src/Cassette.Aspnet/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet/BundleRequestHandler.cs
@@ -94,17 +94,18 @@ namespace Cassette.Aspnet
                 return stream;
             }
 
-            if (encoding.IndexOf("deflate", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                response.AppendHeader("Content-Encoding", "deflate");
-                response.AppendHeader("Vary", "Accept-Encoding");
-                return new DeflateStream(stream, CompressionMode.Compress, true);
-            }
-            else if (encoding.IndexOf("gzip", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                response.AppendHeader("Content-Encoding", "gzip");
-                response.AppendHeader("Vary", "Accept-Encoding");
-                return new GZipStream(stream, CompressionMode.Compress, true);
+            foreach (var type in encoding.Split(',')) {
+                if (type.Equals("deflate", StringComparison.OrdinalIgnoreCase)) {
+                    response.AppendHeader("Content-Encoding", "deflate");
+                    response.AppendHeader("Vary", "Accept-Encoding");
+                    return new DeflateStream(stream, CompressionMode.Compress, true);
+                }
+                else if (type.Equals("gzip", StringComparison.OrdinalIgnoreCase)) {
+                    response.AppendHeader("Content-Encoding", "gzip");
+                    response.AppendHeader("Vary", "Accept-Encoding");
+                    return new GZipStream(stream, CompressionMode.Compress, true);
+                }
+
             }
             return stream;
         }

--- a/src/Cassette.Aspnet/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet/BundleRequestHandler.cs
@@ -97,7 +97,7 @@ namespace Cassette.Aspnet
             foreach (var type in encoding.Split(',')) {
                 var typeComponents = type.Split(';');
                 var typeEncoding = typeComponents[0].Trim();
-                float qvalue = 1.0f;
+                float qvalue = 1.0f;  // TODO: Prioritize qvalue and implement remaining RFC 2616, section 14.3
                 if (typeComponents.Length > 1  && !float.TryParse(typeComponents[1], out qvalue)) {
                     qvalue = 1.0f;
                 }

--- a/src/Cassette.Aspnet/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet/BundleRequestHandler.cs
@@ -95,12 +95,18 @@ namespace Cassette.Aspnet
             }
 
             foreach (var type in encoding.Split(',')) {
-                if (type.Equals("deflate", StringComparison.OrdinalIgnoreCase)) {
+                var typeComponents = type.Split(';');
+                var typeEncoding = typeComponents[0].Trim();
+                float qvalue = 1.0f;
+                if (typeComponents.Length > 1  && !float.TryParse(typeComponents[1], out qvalue)) {
+                    qvalue = 1.0f;
+                }
+                if (typeEncoding.Equals("deflate", StringComparison.OrdinalIgnoreCase)) {
                     response.AppendHeader("Content-Encoding", "deflate");
                     response.AppendHeader("Vary", "Accept-Encoding");
                     return new DeflateStream(stream, CompressionMode.Compress, true);
                 }
-                else if (type.Equals("gzip", StringComparison.OrdinalIgnoreCase)) {
+                else if (typeEncoding.Equals("gzip", StringComparison.OrdinalIgnoreCase)) {
                     response.AppendHeader("Content-Encoding", "gzip");
                     response.AppendHeader("Vary", "Accept-Encoding");
                     return new GZipStream(stream, CompressionMode.Compress, true);

--- a/test.bat
+++ b/test.bat
@@ -1,1 +1,2 @@
-msbuild build.xml /t:test
+set msbuild=%windir%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe
+%msbuild% build.xml /t:test


### PR DESCRIPTION
This more closely adheres to RFC 2616 with respect to Accept-Encoding request handlers.  It works around an issue caused by ASP.NET delivering the incorrect Accept-Encoding values to Cassette.

I've also included a fix to test.bat for systems that do not include msbuild.exe in their path.
