### PR TITLE
Small documentation suggestion

### DIFF
--- a/src/Website/Views/Documentation/v2/BundleConfiguration/AddUrls.cshtml
+++ b/src/Website/Views/Documentation/v2/BundleConfiguration/AddUrls.cshtml
@@ -50,4 +50,4 @@ $(function() {
     if (!window.jQuery) {
         document.write(unescape('%3Cscript src="/cassette.axd/script/PlxtfG4Jll0234wePZ3KZGLEHsE=/scripts/jquery.js" type="text/javascript"%3E%3C/script%3E'));
     }
-&lt;/script&gt;</code></pre>
+&lt;/script&gt;</code></pre><p>Note that this feature will only be activated if debug mode is off (see <a href="@Url.DocumentationUrl("web-config")">web-config</a>)</p>


### PR DESCRIPTION
Hello,

A couple of us here JustGiving have been trying to find out why our CDN-with-fallback bundle wasn't rendering any CDN resources.  I thought I would suggest this update to the documentation just in case anyone else falls into the debug=true trap.

Thanks,

Jon
