### PR TITLE
Instead of just setting statuscode to 404... 

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/AssetRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/AssetRequestHandler.cs
@@ -55,7 +55,8 @@ namespace Cassette.Aspnet
         public void GivenBundleNotFound_WhenProcessRequest_ThenNotFoundResponse()
         {
             bundles.Clear();
-            handler.ProcessRequest(null);
+            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest(null));
+            httpException.GetHttpCode().ShouldEqual(404);
             response.VerifySet(r => r.StatusCode = 404);
         }
 
@@ -63,7 +64,8 @@ namespace Cassette.Aspnet
         public void GivenBundleFoundButAssetIsNull_WhenProcessRequest_ThenNotFoundResponse()
         {
             bundles.Add(new TestableBundle("~/test"));
-            handler.ProcessRequest("~/test/asset.js");
+            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest("~/test/asset.js"));
+            httpException.GetHttpCode().ShouldEqual(404);
             response.VerifySet(r => r.StatusCode = 404);
         }
 

--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -138,9 +138,8 @@ namespace Cassette.Aspnet
         public void HandlerReturns404()
         {
             var handler = CreateRequestHandler();
-
-            handler.ProcessRequest("~/notfound");
-
+            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest("~/notfound"));
+            httpException.GetHttpCode().ShouldEqual(404);
             response.VerifySet(r => r.StatusCode = 404);
         }
     }

--- a/src/Cassette.Aspnet.UnitTests/CachedFileRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/CachedFileRequestHandler.cs
@@ -39,7 +39,8 @@ namespace Cassette.Aspnet
         [Fact]
         public void StatusCode404WhenCacheFileDoesntExist()
         {
-            handler.ProcessRequest("~/notfound");
+            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest("~/notfound"));
+            httpException.GetHttpCode().ShouldEqual(404);
             response.VerifySet(r => r.StatusCode = 404);
         }
 

--- a/src/Cassette.Aspnet.UnitTests/DiagnosticRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/DiagnosticRequestHandler.cs
@@ -45,8 +45,8 @@ namespace Cassette.Aspnet
             GivenRemoteRequest();
             settings.AllowRemoteDiagnostics = false;
 
-            handler.ProcessRequest();
-
+            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest());
+            httpException.GetHttpCode().ShouldEqual(404);
             response.VerifySet(r => r.StatusCode = 404);
         }
 

--- a/src/Cassette.Aspnet/AssetRequestHandler.cs
+++ b/src/Cassette.Aspnet/AssetRequestHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Web;
+﻿using System.Net;
+using System.Web;
 using System.Web.Routing;
 using Cassette.Utilities;
 using Trace = Cassette.Diagnostics.Trace;
@@ -29,8 +30,8 @@ namespace Cassette.Aspnet
                 if (!bundles.TryGetAssetByPath(path, out asset, out bundle))
                 {
                     Trace.Source.TraceInformation("Bundle asset not found with path \"{0}\".", path);
-                    NotFound(response);
-                    return;
+                    response.StatusCode = (int) HttpStatusCode.NotFound;
+                    throw new HttpException((int) HttpStatusCode.NotFound, "Asset not found");
                 }
 
                 var request = requestContext.HttpContext.Request;
@@ -70,12 +71,6 @@ namespace Cassette.Aspnet
         void SendNotModified(HttpResponseBase response)
         {
             response.StatusCode = 304; // Not Modified
-            response.SuppressContent = true;
-        }
-
-        void NotFound(HttpResponseBase response)
-        {
-            response.StatusCode = 404;
             response.SuppressContent = true;
         }
     }

--- a/src/Cassette.Aspnet/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet/BundleRequestHandler.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
 using System.Web;
 using System.Web.Routing;
 using Cassette.Utilities;
@@ -35,20 +36,19 @@ namespace Cassette.Aspnet
                 if (bundle == null)
                 {
                     Trace.Source.TraceInformation("Bundle not found \"{0}\".", path);
-                    response.StatusCode = 404;
+                    response.StatusCode = (int) HttpStatusCode.NotFound;
+                    throw new HttpException((int) HttpStatusCode.NotFound, "Bundle not found");
+                }
+
+                var actualETag = "\"" + bundle.Hash.ToHexString() + "\"";
+                var givenETag = request.Headers["If-None-Match"];
+                if (givenETag == actualETag)
+                {
+                    SendNotModified(actualETag);
                 }
                 else
                 {
-                    var actualETag = "\"" + bundle.Hash.ToHexString() + "\"";
-                    var givenETag = request.Headers["If-None-Match"];
-                    if (givenETag == actualETag)
-                    {
-                        SendNotModified(actualETag);
-                    }
-                    else
-                    {
-                        SendBundle(bundle, actualETag);
-                    }
+                    SendBundle(bundle, actualETag);
                 }
             }
         }

--- a/src/Cassette.Aspnet/CachedFileRequestHandler.cs
+++ b/src/Cassette.Aspnet/CachedFileRequestHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Net;
 using System.Web;
 using Cassette.IO;
 #if NET35
@@ -23,8 +24,8 @@ namespace Cassette.Aspnet
             var file = cacheDirectory.GetFile(path);
             if (!file.Exists)
             {
-                response.StatusCode = 404;
-                return;
+                response.StatusCode = (int) HttpStatusCode.NotFound;
+                throw new HttpException((int) HttpStatusCode.NotFound, "File not found");
             }
 
             SetContentType(path);

--- a/src/Cassette.Aspnet/DiagnosticRequestHandler.cs
+++ b/src/Cassette.Aspnet/DiagnosticRequestHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using System.Web;
 using System.Web.Routing;
@@ -35,8 +36,8 @@ namespace Cassette.Aspnet
 
             if (!CanAccessHud(request))
             {
-                response.StatusCode = 404;
-                return;
+                response.StatusCode = (int) HttpStatusCode.NotFound;
+                throw new HttpException((int) HttpStatusCode.NotFound, "Not found");
             }
 
             if (request.HttpMethod.Equals("post", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
Throw an httpexception with a 404 statuscode, it's easier to catch handle and provide a friendly 404 message rather than an IIS 404 from the handler.
