### PR TITLE
Add DisableHash setting to ease debugging javascript with Chrome

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/Cassette.Aspnet.UnitTests.csproj
+++ b/src/Cassette.Aspnet.UnitTests/Cassette.Aspnet.UnitTests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="BundleRequestHandler.cs" />
     <Compile Include="CachedFileRequestHandler.cs" />
     <Compile Include="CassetteHttpHandler.cs" />
+    <Compile Include="RawFileRequestRewriterWithoutHash.cs" />
     <Compile Include="DiagnosticRequestHandler.cs" />
     <Compile Include="HttpContextExtensions.cs" />
     <Compile Include="HttpTestHarness.cs" />

--- a/src/Cassette.Aspnet.UnitTests/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet.UnitTests/RawFileRequestRewriter.cs
@@ -43,6 +43,7 @@ namespace Cassette.Aspnet
             var context = new Mock<HttpContextBase>();
             var request = new Mock<HttpRequestBase>();
             var cache = new Mock<HttpCachePolicyBase>();
+            var cassetteSettings = new CassetteSettings();
             var requestHeaders = new NameValueCollection();
             context.SetupGet(c => c.Request).Returns(request.Object);
             context.Setup(c => c.Response.Cache).Returns(cache.Object);
@@ -60,7 +61,7 @@ namespace Cassette.Aspnet
                 .SetupGet(r => r.Headers)
                 .Returns(requestHeaders);
 
-            var rewriter = new RawFileRequestRewriter(context.Object, auth.Object, hasher.Object, usingIntegratedPipeline: true);
+            var rewriter = new RawFileRequestRewriter(context.Object, auth.Object, hasher.Object, cassetteSettings, usingIntegratedPipeline: true);
             rewriter.Rewrite();
 
             context.Verify(c => c.RewritePath(to));

--- a/src/Cassette.Aspnet.UnitTests/RawFileRequestRewriterWithoutHash.cs
+++ b/src/Cassette.Aspnet.UnitTests/RawFileRequestRewriterWithoutHash.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Web;
+using Moq;
+using Xunit;
+
+namespace Cassette.Aspnet
+{
+    public class RawFileRequestRewriterWithoutHash_Tests
+    {
+        [Fact]
+        public void RewriteCallsContextRewritePathMethodPassingTheOriginalFilePath()
+        {
+            AssetRewrite("/file/example/image-01.png", "~/example/image-01.png");
+        }
+
+        [Fact]
+        public void RewriteToleratesFilenameWithHyphen()
+        {
+            AssetRewrite("/file/example/image-test-01.png", "~/example/image-test-01.png");
+        }
+
+        [Fact]
+        public void RewriteToleratesFilenameWithPeriod()
+        {
+            AssetRewrite("/file/example/image.test-01.png", "~/example/image.test-01.png");
+        }
+
+        [Fact]
+        public void RewriteToleratesNoFileExtension()
+        {
+            AssetRewrite("/file/example/image-01", "~/example/image-01");
+        }
+
+        [Fact]
+        public void RewriteToleratesExtensionWithHyphen()
+        {
+            AssetRewrite("/file/example/image-01.png-foo", "~/example/image-01.png-foo");
+        }
+
+        void AssetRewrite(string from, string to)
+        {
+            var context = new Mock<HttpContextBase>();
+            var request = new Mock<HttpRequestBase>();
+            var cache = new Mock<HttpCachePolicyBase>();
+            var cassetteSettings = new CassetteSettings{ IsFileNameWithHashDisabled = true };
+            var requestHeaders = new NameValueCollection();
+            context.SetupGet(c => c.Request).Returns(request.Object);
+            context.Setup(c => c.Response.Cache).Returns(cache.Object);
+            var auth = new Mock<IFileAccessAuthorization>();
+            auth.Setup(a => a.CanAccess(It.IsAny<string>())).Returns(true);
+            var hasher = new Mock<IFileContentHasher>();
+            hasher.Setup(h => h.Hash(It.IsAny<string>())).Returns(new byte[] { 1 });
+            request
+                .SetupGet(r => r.AppRelativeCurrentExecutionFilePath)
+                .Returns("~/cassette.axd");
+            request
+                .SetupGet(r => r.PathInfo)
+                .Returns(from);
+            request
+                .SetupGet(r => r.Headers)
+                .Returns(requestHeaders);
+
+            var rewriter = new RawFileRequestRewriter(context.Object, auth.Object, hasher.Object, cassetteSettings, usingIntegratedPipeline: true);
+            rewriter.Rewrite();
+
+            context.Verify(c => c.RewritePath(to));
+        }
+    }
+}

--- a/src/Cassette.Aspnet/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet/RawFileRequestRewriter.cs
@@ -10,20 +10,22 @@ namespace Cassette.Aspnet
         readonly HttpContextBase context;
         readonly IFileAccessAuthorization fileAccessAuthorization;
         readonly IFileContentHasher fileContentHasher;
+        readonly CassetteSettings cassetteSettings;
         readonly HttpRequestBase request;
         readonly MimeMappingWrapper mimeMapping;
         readonly Action<string> rewritePath;
 
-        public RawFileRequestRewriter(HttpContextBase context, IFileAccessAuthorization fileAccessAuthorization, IFileContentHasher fileContentHasher)
-            : this(context, fileAccessAuthorization, fileContentHasher, HttpRuntime.UsingIntegratedPipeline)
+        public RawFileRequestRewriter(HttpContextBase context, IFileAccessAuthorization fileAccessAuthorization, IFileContentHasher fileContentHasher, CassetteSettings cassetteSettings)
+            : this(context, fileAccessAuthorization, fileContentHasher, cassetteSettings, HttpRuntime.UsingIntegratedPipeline)
         {
         }
 
-        public RawFileRequestRewriter(HttpContextBase context, IFileAccessAuthorization fileAccessAuthorization, IFileContentHasher fileContentHasher, bool usingIntegratedPipeline)
+        public RawFileRequestRewriter(HttpContextBase context, IFileAccessAuthorization fileAccessAuthorization, IFileContentHasher fileContentHasher, CassetteSettings cassetteSettings, bool usingIntegratedPipeline)
         {
             this.context = context;
             this.fileAccessAuthorization = fileAccessAuthorization;
             this.fileContentHasher = fileContentHasher;
+            this.cassetteSettings = cassetteSettings;
             request = context.Request;
 
             // RewritePath doesn't work as expected in IIS 6 or IIS 7 Classic pipeline
@@ -113,6 +115,9 @@ namespace Cassette.Aspnet
 
         string RemoveHashFromPath(string path)
         {
+            if (cassetteSettings.IsFileNameWithHashDisabled)
+                return path;
+
             // "example/image-hash.png" -> "example/image.png"
             // "example/image-hash.png-foo" -> "example/image.png-foo"
             // "example/image-hash" -> "example/image"

--- a/src/Cassette.Aspnet/WebHostSettingsConfiguration.cs
+++ b/src/Cassette.Aspnet/WebHostSettingsConfiguration.cs
@@ -30,6 +30,9 @@ namespace Cassette.Aspnet
             settings.CacheDirectory = GetCacheDirectory(configurationSection);
             settings.IsFileSystemWatchingEnabled = TrustLevel.IsFullTrust() && !IsStaticCacheManifest(settings);
 
+            // only allow this setting to be specified from the config settings when in debug mode
+            settings.IsFileNameWithHashDisabled = settings.IsDebuggingEnabled && configurationSection.DisableHash;
+
             IsStaticCacheManifest(settings);
 
             // Include the virtual directory so that if the application is moved to 

--- a/src/Cassette.UnitTests/Cassette.UnitTests.csproj
+++ b/src/Cassette.UnitTests/Cassette.UnitTests.csproj
@@ -142,6 +142,8 @@
     <Compile Include="BundleCollection.AddUrl.cs" />
     <Compile Include="BundleCollection.AddPerIndividualFile.cs" />
     <Compile Include="CassetteSettings.cs" />
+    <Compile Include="UrlGenerator_CreateAssetUrlWithoutHash_Tests.cs" />
+    <Compile Include="UrlGenerator_CreateRawFileUrlWithoutHash_Tests.cs" />
     <Compile Include="DisposableLazy.cs" />
     <Compile Include="ExceptionCatchingBundleCollectionInitializer.cs" />
     <Compile Include="FileSearch.IsMatch.cs" />

--- a/src/Cassette.UnitTests/UrlGeneratorTestsBase.cs
+++ b/src/Cassette.UnitTests/UrlGeneratorTestsBase.cs
@@ -8,12 +8,16 @@ namespace Cassette
         protected readonly FakeFileSystem SourceDirectory = new FakeFileSystem();
         internal readonly UrlGenerator UrlGenerator;
 
-        protected UrlGeneratorTestsBase()
+        protected UrlGeneratorTestsBase() : this(false)
+        {
+        }
+
+        protected UrlGeneratorTestsBase(bool isFileNameWithHashDisabled)
         {
             UrlModifier.Setup(m => m.Modify(It.IsAny<string>()))
                        .Returns<string>(url => url);
 
-            UrlGenerator = new UrlGenerator(UrlModifier.Object, SourceDirectory, "cassette.axd/");
+            UrlGenerator = new UrlGenerator(UrlModifier.Object, SourceDirectory, "cassette.axd/", isFileNameWithHashDisabled);
         }
     }
 }

--- a/src/Cassette.UnitTests/UrlGenerator_CreateAssetUrlWithoutHash_Tests.cs
+++ b/src/Cassette.UnitTests/UrlGenerator_CreateAssetUrlWithoutHash_Tests.cs
@@ -1,0 +1,68 @@
+using Cassette.Utilities;
+using Moq;
+using Should;
+using Xunit;
+
+namespace Cassette
+{
+    public class UrlGenerator_CreateAssetUrlWithoutHash_Tests : UrlGeneratorTestsBase
+    {
+        readonly Mock<IAsset> asset;
+
+        public UrlGenerator_CreateAssetUrlWithoutHash_Tests() : base(true)
+        {
+            asset = new Mock<IAsset>();
+            asset.SetupGet(a => a.Hash).Returns(new byte[] { 1, 2, 15, 16 });
+        }
+
+        [Fact]
+        public void UrlModifierModifyIsCalled()
+        {
+            asset.SetupGet(a => a.Path).Returns("~/test/asset.coffee");
+
+            UrlGenerator.CreateAssetUrl(asset.Object);
+
+            UrlModifier.Verify(m => m.Modify(It.IsAny<string>()));
+        }
+
+        [Fact]
+        public void CreateAssetUrlReturnsUrlWithTheAssetPath()
+        {
+            asset.SetupGet(a => a.Path).Returns("~/test/asset.coffee");
+
+            var url = UrlGenerator.CreateAssetUrl(asset.Object);
+
+            url.ShouldEqual("cassette.axd/asset/test/asset.coffee");
+        }
+
+        [Fact]
+        public void CreateAssetUrlWherePathIsInRootDirectoryReturnsUrlWithTheAssetPath()
+        {
+            asset.SetupGet(a => a.Path).Returns("~/asset.coffee");
+
+            var url = UrlGenerator.CreateAssetUrl(asset.Object);
+
+            url.ShouldEqual("cassette.axd/asset/asset.coffee");
+        }
+
+        [Fact]
+        public void CreateAssetUrlWherePathHasNoExtensionReturnsUrlWithTheAssetPath()
+        {
+            asset.SetupGet(a => a.Path).Returns("~/test/asset");
+
+            var url = UrlGenerator.CreateAssetUrl(asset.Object);
+
+            url.ShouldEqual("cassette.axd/asset/test/asset");
+        }
+
+        [Fact]
+        public void CreateAssetUrlWherePathHasPeriodsInDirectoryNamesReturnsUrlWithTheAssetPath()
+        {
+            asset.SetupGet(a => a.Path).Returns("~/test.test/asset.coffee");
+
+            var url = UrlGenerator.CreateAssetUrl(asset.Object);
+
+            url.ShouldEqual("cassette.axd/asset/test.test/asset.coffee");
+        }
+    }
+}

--- a/src/Cassette.UnitTests/UrlGenerator_CreateRawFileUrlWithoutHash_Tests.cs
+++ b/src/Cassette.UnitTests/UrlGenerator_CreateRawFileUrlWithoutHash_Tests.cs
@@ -1,0 +1,53 @@
+using System;
+using Should;
+using Xunit;
+
+namespace Cassette
+{
+    public class UrlGenerator_CreateRawFileUrlWithoutHash_Tests : UrlGeneratorTestsBase
+    {
+        public UrlGenerator_CreateRawFileUrlWithoutHash_Tests() : base(true)
+        {
+        }
+
+        [Fact]
+        public void CreateRawFileUrlReturnsUrlWithRoutePrefixAndHashAndPathWithoutTilde()
+        {
+            SourceDirectory.Add("~\\test.png", "content");
+            var url = UrlGenerator.CreateRawFileUrl("~/test.png");
+            url.ShouldEqual("cassette.axd/file/test.png");
+        }
+
+        [Fact]
+        public void ConvertsToForwardSlashes()
+        {
+            SourceDirectory.Add("~\\test\\foo.png", "content");
+            var url = UrlGenerator.CreateRawFileUrl("~\\test\\foo.png");
+            url.ShouldEqual("cassette.axd/file/test/foo.png");
+        }
+
+        [Fact]
+        public void ToleratesFilenameWithoutExtension()
+        {
+            SourceDirectory.Add("~\\test\\foo", "content");
+            var url = UrlGenerator.CreateRawFileUrl("~\\test\\foo");
+            url.ShouldEqual("cassette.axd/file/test/foo");
+        }
+
+        [Fact]
+        public void InsertsHashBeforeLastPeriod()
+        {
+            SourceDirectory.Add("~\\test\\foo.bar.png", "content");
+            var url = UrlGenerator.CreateRawFileUrl("~\\test\\foo.bar.png");
+            url.ShouldEqual("cassette.axd/file/test/foo.bar.png");
+        }
+
+        [Fact]
+        public void EscapesSpaces()
+        {
+            SourceDirectory.Add("~\\space test.png", "content");
+            var url = UrlGenerator.CreateRawFileUrl("~/space test.png");
+            url.ShouldEqual("cassette.axd/file/space%20test.png");
+        }
+    }
+}

--- a/src/Cassette/CassetteConfigurationSection.cs
+++ b/src/Cassette/CassetteConfigurationSection.cs
@@ -11,6 +11,13 @@ namespace Cassette
             set { this["debug"] = value; }
         }
 
+        [ConfigurationProperty("disableHash", DefaultValue = false)]
+        public bool DisableHash
+        {
+            get { return (bool)this["disableHash"]; }
+            set { this["disableHash"] = value; }
+        }
+
         [ConfigurationProperty("rewriteHtml", DefaultValue = true)]
         public bool RewriteHtml
         {

--- a/src/Cassette/CassetteSettings.cs
+++ b/src/Cassette/CassetteSettings.cs
@@ -33,6 +33,8 @@ namespace Cassette
         /// </summary>
         public bool IsDebuggingEnabled { get; set; }
 
+        public bool IsFileNameWithHashDisabled { get; set; }
+
         /// <summary>
         /// When true (the default), Cassette will buffer page output and rewrite to allow bundle references to be inserted into &lt;head&gt;
         /// after it has already been rendered. Disable this when &lt;system.webServer&gt;/&lt;urlCompression dynamicCompressionBeforeCache="true"&gt;

--- a/src/Cassette/HostBase.cs
+++ b/src/Cassette/HostBase.cs
@@ -107,7 +107,7 @@ namespace Cassette
 
         void RegisterUrlGenerator()
         {
-            container.Register<IUrlGenerator>((c, n) => new UrlGenerator(c.Resolve<IUrlModifier>(), c.Resolve<CassetteSettings>().SourceDirectory, "cassette.axd/"));
+            container.Register<IUrlGenerator>((c, n) => new UrlGenerator(c.Resolve<IUrlModifier>(), c.Resolve<CassetteSettings>().SourceDirectory, "cassette.axd/", c.Resolve<CassetteSettings>().IsFileNameWithHashDisabled));
         }
 
         void RegisterCache()


### PR DESCRIPTION
Javascript break points were being lost in Chrome every time the file changed because Chrome uses the entire path for applying saved break points.

This change adds a configuration setting to allow the file hash to not be added to the asset file names during debug.
