### PR TITLE
Fixed serving of static files under IIS 6 / IIS 7 classic pipeline.

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet.UnitTests/RawFileRequestRewriter.cs
@@ -60,7 +60,7 @@ namespace Cassette.Aspnet
                 .SetupGet(r => r.Headers)
                 .Returns(requestHeaders);
 
-            var rewriter = new RawFileRequestRewriter(context.Object, auth.Object, hasher.Object);
+            var rewriter = new RawFileRequestRewriter(context.Object, auth.Object, hasher.Object, usingIntegratedPipeline: true);
             rewriter.Rewrite();
 
             context.Verify(c => c.RewritePath(to));

--- a/src/Cassette.Aspnet/Cassette.Aspnet.csproj
+++ b/src/Cassette.Aspnet/Cassette.Aspnet.csproj
@@ -82,6 +82,7 @@
     <Compile Include="ICassetteRequestHandler.cs" />
     <Compile Include="IDiagnosticRequestHandler.cs" />
     <Compile Include="ContentTypes.cs" />
+    <Compile Include="MimeMappingWrapper.cs" />
     <Compile Include="RawFileRequestRewriter.cs" />
     <Compile Include="TrustLevel.cs" />
     <Compile Include="WebHost.cs" />

--- a/src/Cassette.Aspnet/MimeMappingWrapper.cs
+++ b/src/Cassette.Aspnet/MimeMappingWrapper.cs
@@ -1,0 +1,44 @@
+﻿using System.Reflection;
+using System.Web;
+
+namespace Cassette.Aspnet
+{
+	/// <summary>
+	/// Wrapper around System.Web.MimeMapping which is an internal class.
+	/// </summary>
+	public class MimeMappingWrapper
+	{
+		readonly MethodInfo mimeMappingMethod;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="MimeMappingWrapper"/> class.
+		/// </summary>
+		public MimeMappingWrapper()
+		{
+			// MimeMapping is internal to System.Web so we need to get it via reflection
+			// http://stackoverflow.com/a/1302366/210370
+			var assembly = Assembly.GetAssembly(typeof(HttpApplication));
+			var type = assembly.GetType("System.Web.MimeMapping");
+			mimeMappingMethod = type.GetMethod("GetMimeMapping", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+		}
+
+		/// <summary>
+		/// Gets the MIME type of the specified file.
+		/// </summary>
+		/// <param name="fileName">Name of the file.</param>
+		/// <returns>MIME type of the file, or <c>application/octet-stream</c> if the extension is unrecognised</returns>
+		public string GetMimeMapping(string fileName)
+		{
+			var extension = fileName.Substring(fileName.LastIndexOf('.'));
+			switch (extension)
+			{
+				// PNG isn't in the MimeMapping class :(
+				case ".png":
+					return "image/png";
+				default:
+					return (string)mimeMappingMethod.Invoke(null, new[] { fileName });
+			}
+			
+		}
+	}
+}

--- a/src/Cassette.Aspnet/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet/RawFileRequestRewriter.cs
@@ -81,7 +81,7 @@ namespace Cassette.Aspnet
             // Since we're not using the static file handler, we also need to set content type manually
             context.Response.ContentType = mimeMapping.GetMimeMapping(path);
             context.Response.TransmitFile(path);
-            context.Response.End();
+            context.ApplicationInstance.CompleteRequest();
         }
 
         void NoCache(HttpResponseBase response)

--- a/src/Cassette.Aspnet/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet/RawFileRequestRewriter.cs
@@ -11,13 +11,33 @@ namespace Cassette.Aspnet
         readonly IFileAccessAuthorization fileAccessAuthorization;
         readonly IFileContentHasher fileContentHasher;
         readonly HttpRequestBase request;
+        readonly MimeMappingWrapper mimeMapping;
+        readonly Action<string> rewritePath;
 
         public RawFileRequestRewriter(HttpContextBase context, IFileAccessAuthorization fileAccessAuthorization, IFileContentHasher fileContentHasher)
+            : this(context, fileAccessAuthorization, fileContentHasher, HttpRuntime.UsingIntegratedPipeline)
+        {
+        }
+
+        public RawFileRequestRewriter(HttpContextBase context, IFileAccessAuthorization fileAccessAuthorization, IFileContentHasher fileContentHasher, bool usingIntegratedPipeline)
         {
             this.context = context;
             this.fileAccessAuthorization = fileAccessAuthorization;
             this.fileContentHasher = fileContentHasher;
             request = context.Request;
+
+            // RewritePath doesn't work as expected in IIS 6 or IIS 7 Classic pipeline
+            // Check if integrated pipeline is in use, and fall back to an alternate method if not.
+            if (usingIntegratedPipeline)
+            {
+                rewritePath = RewritePathIntegratedPipeline;
+            }
+            else
+            {
+                rewritePath = RewritePathClassicPipeline;
+                // Only required for classic pipeline
+                mimeMapping = new MimeMappingWrapper();
+            }
         }
 
         public void Rewrite()
@@ -47,7 +67,21 @@ namespace Cassette.Aspnet
                 SendNotModified(context.Response);
             }
 
+            rewritePath(path);
+        }
+
+        void RewritePathIntegratedPipeline(string path)
+        {
             context.RewritePath(path);
+        }
+
+        void RewritePathClassicPipeline(string path)
+        {
+            path = context.Server.MapPath(path);
+            // Since we're not using the static file handler, we also need to set content type manually
+            context.Response.ContentType = mimeMapping.GetMimeMapping(path);
+            context.Response.TransmitFile(path);
+            context.Response.End();
         }
 
         void NoCache(HttpResponseBase response)


### PR DESCRIPTION
This fixes issue #381. `context.RewritePath` does not work properly for serving static files on IIS 6 (or IIS 7 with classic pipeline). Cassette is setting an ETag, and the framework `StaticFileHandler` also tries to set an ETag, which causes this error. However, even with the ETag line commented out, most of the headers (like the expiry date) were not set correctly on IIS 6.

I've changed the code to continue using `context.RewritePath` when using the integrated pipeline, and fall back to `context.Response.TransmitFile` for IIS 6.
