### PR TITLE
Use Action<T> instead of Action<Bundle> in generic overloads

### DIFF
--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -419,7 +419,7 @@ namespace Cassette
             }
         }
 
-        public void AddUrlWithLocalAssets<T>(string url, LocalAssetSettings localAssetSettings, Action<Bundle> customizeBundle = null)
+        public void AddUrlWithLocalAssets<T>(string url, LocalAssetSettings localAssetSettings, Action<T> customizeBundle = null)
             where T : Bundle
         {
             var existingBundle = bundles.FirstOrDefault(
@@ -481,7 +481,7 @@ namespace Cassette
             }
         }
 
-        public void AddUrlWithAlias<T>(string url, string alias, Action<Bundle> customizeBundle = null)
+        public void AddUrlWithAlias<T>(string url, string alias, Action<T> customizeBundle = null)
             where T : Bundle
         {
             var bundleFactory = bundleFactoryProvider.GetBundleFactory<T>();
@@ -501,7 +501,7 @@ namespace Cassette
         /// <param name="url">The URL to reference.</param>
         /// <param name="customizeBundle">A delegate that is called for each created bundle to allow customization.</param>
         /// <returns>A object used to further configure the bundle.</returns>
-        public void AddUrl<T>(string url, Action<Bundle> customizeBundle = null)
+        public void AddUrl<T>(string url, Action<T> customizeBundle = null)
             where T : Bundle
         {
             var bundleFactory = bundleFactoryProvider.GetBundleFactory<T>();


### PR DESCRIPTION
This allows customisation of bundle-specific properties.
