### PR TITLE
Embedded resource improvements

### DIFF
--- a/src/Cassette.Aspnet/DiagnosticBundleConfiguration.cs
+++ b/src/Cassette.Aspnet/DiagnosticBundleConfiguration.cs
@@ -1,30 +1,21 @@
-﻿using System.Linq;
-using System.Reflection;
-using Cassette.IO;
+﻿using System.Reflection;
 using Cassette.Scripts;
 
 namespace Cassette.Aspnet
 {
     public class DiagnosticBundleConfiguration : IConfiguration<BundleCollection>
     {
-        readonly IBundleFactory<ScriptBundle> scriptBundleFactory;
-
-        public DiagnosticBundleConfiguration(IBundleFactory<ScriptBundle> scriptBundleFactory)
-        {
-            this.scriptBundleFactory = scriptBundleFactory;
-        }
-
         public void Configure(BundleCollection bundles)
         {
-            var scriptBundle = scriptBundleFactory.CreateBundle(
-                "~/Cassette.Aspnet.Resources",
-                Enumerable.Empty<IFile>(),
-                new BundleDescriptor { AssetFilenames = { "*" } }
-                );
-            scriptBundle.Assets.Add(new ResourceAsset("Cassette.Aspnet.Resources.jquery.js", Assembly.GetExecutingAssembly()));
-            scriptBundle.Assets.Add(new ResourceAsset("Cassette.Aspnet.Resources.knockout.js", Assembly.GetExecutingAssembly()));
-            scriptBundle.Assets.Add(new ResourceAsset("Cassette.Aspnet.Resources.diagnostic-page.js", Assembly.GetExecutingAssembly()));
-            bundles.Add(scriptBundle);
+			bundles.AddEmbeddedResources<ScriptBundle>(
+				"~/Cassette.Aspnet.Resources",
+				Assembly.GetExecutingAssembly(),
+				"Cassette.Aspnet.Resources",
+
+				"jquery.js",
+				"knockout.js",
+				"diagnostic-page.js"
+			);
         }
     }
 }

--- a/src/Cassette.Aspnet/DiagnosticBundleConfiguration.cs
+++ b/src/Cassette.Aspnet/DiagnosticBundleConfiguration.cs
@@ -7,15 +7,15 @@ namespace Cassette.Aspnet
     {
         public void Configure(BundleCollection bundles)
         {
-			bundles.AddEmbeddedResources<ScriptBundle>(
-				"~/Cassette.Aspnet.Resources",
-				Assembly.GetExecutingAssembly(),
-				"Cassette.Aspnet.Resources",
+            bundles.AddEmbeddedResources<ScriptBundle>(
+                "~/Cassette.Aspnet.Resources",
+                Assembly.GetExecutingAssembly(),
+                "Cassette.Aspnet.Resources",
 
-				"jquery.js",
-				"knockout.js",
-				"diagnostic-page.js"
-			);
+                "jquery.js",
+                "knockout.js",
+                "diagnostic-page.js"
+            );
         }
     }
 }

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -563,58 +563,58 @@ namespace Cassette
             }
         }
 
-	    /// <summary>
-	    /// Adds a new bundle with an explicit list of assets retrieved from embedded resources
-	    /// </summary>
-	    /// <typeparam name="T">The type of bundle to add.</typeparam>
-	    /// <param name="applicationRelativePath">The application relative path of the bundle. This does not have to be a real directory path.</param>
-	    /// <param name="assembly">Assembly to retrieve assets from</param>
-		/// <param name="resourceNamespace">Base namespace to retrieve assets from</param>
-		/// <param name="resourceFilenames">The filenames of resources to add to the bundle. The order given here will be preserved. Filenames are bundle directory relative, if the bundle path exists, otherwise they are application relative.</param>
-	    public void AddEmbeddedResources<T>(string applicationRelativePath, Assembly assembly, string resourceNamespace, params string[] resourceFilenames)
-			where T : Bundle
-		{
-			AddEmbeddedResources<T>(applicationRelativePath, assembly, resourceNamespace, resourceFilenames, null);
-		}
+        /// <summary>
+        /// Adds a new bundle with an explicit list of assets retrieved from embedded resources
+        /// </summary>
+        /// <typeparam name="T">The type of bundle to add.</typeparam>
+        /// <param name="applicationRelativePath">The application relative path of the bundle. This does not have to be a real directory path.</param>
+        /// <param name="assembly">Assembly to retrieve assets from</param>
+        /// <param name="resourceNamespace">Base namespace to retrieve assets from</param>
+        /// <param name="resourceFilenames">The filenames of resources to add to the bundle. The order given here will be preserved. Filenames are bundle directory relative, if the bundle path exists, otherwise they are application relative.</param>
+        public void AddEmbeddedResources<T>(string applicationRelativePath, Assembly assembly, string resourceNamespace, params string[] resourceFilenames)
+            where T : Bundle
+        {
+            AddEmbeddedResources<T>(applicationRelativePath, assembly, resourceNamespace, resourceFilenames, null);
+        }
 
-		/// <summary>
-		/// Adds a new bundle with an explicit list of assets retrieved from embedded resources
-		/// </summary>
-		/// <typeparam name="T">The type of bundle to add.</typeparam>
-		/// <param name="applicationRelativePath">The application relative path of the bundle. This does not have to be a real directory path.</param>
-		/// <param name="assembly">Assembly to retrieve assets from</param>
-		/// <param name="resourceNamespace">Base namespace to retrieve assets from</param>
-		/// <param name="resourceFilenames">The filenames of resources to add to the bundle. The order given here will be preserved. Filenames are bundle directory relative, if the bundle path exists, otherwise they are application relative.</param>
-		/// <param name="customizeBundle">An action delegate used to customize the created bundle.</param>
-		public void AddEmbeddedResources<T>(string applicationRelativePath, Assembly assembly, string resourceNamespace, IEnumerable<string> resourceFilenames, Action<T> customizeBundle = null)
-			where T : Bundle
-		{
-			var factory = bundleFactoryProvider.GetBundleFactory<T>();
+        /// <summary>
+        /// Adds a new bundle with an explicit list of assets retrieved from embedded resources
+        /// </summary>
+        /// <typeparam name="T">The type of bundle to add.</typeparam>
+        /// <param name="applicationRelativePath">The application relative path of the bundle. This does not have to be a real directory path.</param>
+        /// <param name="assembly">Assembly to retrieve assets from</param>
+        /// <param name="resourceNamespace">Base namespace to retrieve assets from</param>
+        /// <param name="resourceFilenames">The filenames of resources to add to the bundle. The order given here will be preserved. Filenames are bundle directory relative, if the bundle path exists, otherwise they are application relative.</param>
+        /// <param name="customizeBundle">An action delegate used to customize the created bundle.</param>
+        public void AddEmbeddedResources<T>(string applicationRelativePath, Assembly assembly, string resourceNamespace, IEnumerable<string> resourceFilenames, Action<T> customizeBundle = null)
+            where T : Bundle
+        {
+            var factory = bundleFactoryProvider.GetBundleFactory<T>();
 
-			var bundle = factory.CreateBundle(
-				applicationRelativePath,
-				Enumerable.Empty<IFile>(),
-				new BundleDescriptor { AssetFilenames = { "*" } }
-			);
+            var bundle = factory.CreateBundle(
+                applicationRelativePath,
+                Enumerable.Empty<IFile>(),
+                new BundleDescriptor { AssetFilenames = { "*" } }
+            );
 
-			if (!resourceNamespace.EndsWith("."))
-				resourceNamespace += ".";
+            if (!resourceNamespace.EndsWith("."))
+                resourceNamespace += ".";
 
-			foreach (var file in resourceFilenames)
-			{
-				// File name can be supplied like a file name (eg. "js/global/test.js") and will be converted to
-				// a full resource name (eg. MySpace.Resources.js.global.test.js)
-				var cleanName = resourceNamespace + file.Replace('/', '.');
-				bundle.Assets.Add(new ResourceAsset(cleanName, assembly));
-			}
+            foreach (var file in resourceFilenames)
+            {
+                // File name can be supplied like a file name (eg. "js/global/test.js") and will be converted to
+                // a full resource name (eg. MySpace.Resources.js.global.test.js)
+                var cleanName = resourceNamespace + file.Replace('/', '.');
+                bundle.Assets.Add(new ResourceAsset(cleanName, assembly));
+            }
 
-			if (customizeBundle != null)
-			{
-				customizeBundle(bundle);
-			}
+            if (customizeBundle != null)
+            {
+                customizeBundle(bundle);
+            }
 
-			Add(bundle);
-		}
+            Add(bundle);
+        }
 
         /// <summary>
         /// Gets a strongly-typed <see cref="Bundle"/> from the collection, by path.

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -603,7 +603,7 @@ namespace Cassette
             foreach (var file in resourceFilenames)
             {
                 // File name can be supplied like a file name (eg. "js/global/test.js") and will be converted to
-                // a full resource name (eg. MySpace.Resources.js.global.test.js)
+                // a full resource name (eg. MyApp.Resources.js.global.test.js)
                 var cleanName = resourceNamespace + file.Replace('/', '.');
                 bundle.Assets.Add(new ResourceAsset(cleanName, assembly));
             }

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using Cassette.IO;
 using Cassette.Utilities;
@@ -561,6 +562,59 @@ namespace Cassette
                 Add(bundle);
             }
         }
+
+	    /// <summary>
+	    /// Adds a new bundle with an explicit list of assets retrieved from embedded resources
+	    /// </summary>
+	    /// <typeparam name="T">The type of bundle to add.</typeparam>
+	    /// <param name="applicationRelativePath">The application relative path of the bundle. This does not have to be a real directory path.</param>
+	    /// <param name="assembly">Assembly to retrieve assets from</param>
+		/// <param name="resourceNamespace">Base namespace to retrieve assets from</param>
+		/// <param name="resourceFilenames">The filenames of resources to add to the bundle. The order given here will be preserved. Filenames are bundle directory relative, if the bundle path exists, otherwise they are application relative.</param>
+	    public void AddEmbeddedResources<T>(string applicationRelativePath, Assembly assembly, string resourceNamespace, params string[] resourceFilenames)
+			where T : Bundle
+		{
+			AddEmbeddedResources<T>(applicationRelativePath, assembly, resourceNamespace, resourceFilenames, null);
+		}
+
+		/// <summary>
+		/// Adds a new bundle with an explicit list of assets retrieved from embedded resources
+		/// </summary>
+		/// <typeparam name="T">The type of bundle to add.</typeparam>
+		/// <param name="applicationRelativePath">The application relative path of the bundle. This does not have to be a real directory path.</param>
+		/// <param name="assembly">Assembly to retrieve assets from</param>
+		/// <param name="resourceNamespace">Base namespace to retrieve assets from</param>
+		/// <param name="resourceFilenames">The filenames of resources to add to the bundle. The order given here will be preserved. Filenames are bundle directory relative, if the bundle path exists, otherwise they are application relative.</param>
+		/// <param name="customizeBundle">An action delegate used to customize the created bundle.</param>
+		public void AddEmbeddedResources<T>(string applicationRelativePath, Assembly assembly, string resourceNamespace, IEnumerable<string> resourceFilenames, Action<T> customizeBundle = null)
+			where T : Bundle
+		{
+			var factory = bundleFactoryProvider.GetBundleFactory<T>();
+
+			var bundle = factory.CreateBundle(
+				applicationRelativePath,
+				Enumerable.Empty<IFile>(),
+				new BundleDescriptor { AssetFilenames = { "*" } }
+			);
+
+			if (!resourceNamespace.EndsWith("."))
+				resourceNamespace += ".";
+
+			foreach (var file in resourceFilenames)
+			{
+				// File name can be supplied like a file name (eg. "js/global/test.js") and will be converted to
+				// a full resource name (eg. MySpace.Resources.js.global.test.js)
+				var cleanName = resourceNamespace + file.Replace('/', '.');
+				bundle.Assets.Add(new ResourceAsset(cleanName, assembly));
+			}
+
+			if (customizeBundle != null)
+			{
+				customizeBundle(bundle);
+			}
+
+			Add(bundle);
+		}
 
         /// <summary>
         /// Gets a strongly-typed <see cref="Bundle"/> from the collection, by path.

--- a/src/Cassette/ResourceAsset.cs
+++ b/src/Cassette/ResourceAsset.cs
@@ -35,7 +35,7 @@ namespace Cassette
             }
         }
 
-	    public override string Path
+        public override string Path
         {
             get { return "~/" + resourceName; }
         }

--- a/src/Cassette/ResourceAsset.cs
+++ b/src/Cassette/ResourceAsset.cs
@@ -10,7 +10,7 @@ namespace Cassette
     /// <summary>
     /// Partial implementation of IAsset that reads from an assembly resource stream.
     /// </summary>
-    public class ResourceAsset : IAsset
+    public class ResourceAsset : AssetBase
     {
         readonly string resourceName;
         readonly Assembly assembly;
@@ -21,7 +21,7 @@ namespace Cassette
             this.assembly = assembly;
         }
 
-        public byte[] Hash
+        public override byte[] Hash
         {
             get
             {
@@ -35,35 +35,30 @@ namespace Cassette
             }
         }
 
-        public string Path
+	    public override string Path
         {
             get { return "~/" + resourceName; }
         }
 
-        public IEnumerable<AssetReference> References
+        public override IEnumerable<AssetReference> References
         {
             get { yield break; }
         }
 
-        public void Accept(IBundleVisitor visitor)
+        public override void Accept(IBundleVisitor visitor)
         {
             visitor.Visit(this);
         }
 
-        public void AddAssetTransformer(IAssetTransformer transformer)
-        {
-            // No transformations applied. Asset served as-is.
-        }
-
-        public void AddReference(string assetRelativePath, int lineNumber)
+        public override void AddReference(string assetRelativePath, int lineNumber)
         {
         }
 
-        public void AddRawFileReference(string relativeFilename)
+        public override void AddRawFileReference(string relativeFilename)
         {
         }
 
-        public Stream OpenStream()
+        protected override Stream OpenStreamCore()
         {
             var stream = assembly.GetManifestResourceStream(resourceName);
             if (stream != null)
@@ -82,7 +77,7 @@ namespace Cassette
             }
         }
 
-        public Type AssetCacheValidatorType
+        public override Type AssetCacheValidatorType
         {
             get { return typeof(ResourceAssetCacheValidator); }
         }

--- a/src/Website/Views/Documentation/v2/BundleConfiguration/AddEmbeddedResources.cshtml
+++ b/src/Website/Views/Documentation/v2/BundleConfiguration/AddEmbeddedResources.cshtml
@@ -1,0 +1,45 @@
+﻿<h1>Embedded resources</h1>
+
+<p>
+    The <code>BundleCollection.AddEmbeddedResources</code> method adds a bundle of embedded resources
+    to the collection. 
+</p>
+<pre><code>
+bundles.AddEmbeddedResources&lt;ScriptBundle>("~/MyResources",
+    // Assembly containing resources
+    Assembly.GetExecutingAssembly(),
+
+    // Base namespace of resources
+    // Default namespace of the assembly plus any parent directory names
+    "MyApp.Resources",
+    
+    // All the resource files to combine
+    "resource1.js",
+    "resource2.js",
+    // ...
+);
+</code></pre>
+<p>
+    Embedded resource bundles behave similarly to standard Cassette bundles, except references
+    between files are not used, and you need to explicitly specify all the references to bundle.
+</p>
+<p>
+    An embedded resource can be added to a regular bundle by adding a <code>ResourceAsset</code>
+    to the bundle:
+</p>
+
+<pre><code>
+bundles.Add&lt;StylesheetBundle>("~/MyBundle", new[]
+{
+    // All the standard CSS files to bundle
+    "Content/css/example1.css",
+    "Content/css/example2.css",
+}, bundle =>
+{
+    var assembly = GetType().Assembly;
+    // Add all the embedded resources
+    bundle.Assets.Add(new ResourceAsset("MyApp.Resources.css.example3.less", assembly));
+    bundle.Assets.Add(new ResourceAsset("MyApp.Resources.css.example4.less", assembly));
+});
+
+</code></pre>

--- a/src/Website/Views/Documentation/v2/_Tree.cshtml
+++ b/src/Website/Views/Documentation/v2/_Tree.cshtml
@@ -10,6 +10,7 @@
                 <li>@DocLink("bundle-configuration/add-per-sub-directory", "AddPerSubDirectory")</li>
                 <li>@DocLink("bundle-configuration/add-per-individual-file", "AddPerIndividualFile")</li>
                 <li>@DocLink("bundle-configuration/add-urls", "Adding external URLs")</li>
+                <li>@DocLink("bundle-configuration/add-embedded-resources", "Embedded resources")</li>
                 <li>@DocLink("bundle-configuration/file-search", "File search")</li>
                 <li>@DocLink("bundle-configuration/customize-bundles", "Customize bundles")</li>
             </ul>

--- a/src/Website/Website.csproj
+++ b/src/Website/Website.csproj
@@ -373,6 +373,9 @@
   <ItemGroup>
     <Content Include="Views\Documentation\v2\Stylesheets\ImageSpriting.cshtml" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="Views\Documentation\v2\BundleConfiguration\AddEmbeddedResources.cshtml" />
+  </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>


### PR DESCRIPTION
Some improvements to how embedded resources are handled:
- Added a `BundleCollection.AddEmbeddedResources` method. Example usage:

``` csharp
bundles.AddEmbeddedResources<ScriptBundle>("~/testjs", GetType().Assembly, "MyApp.Resources",
    "js/test1.js",
    "js/test2.js"
);
```
- Modified `ResourceAsset` to inherit from `AssetBase` so transforms are applied.
