### PR TITLE
Proper cache validation for resource assets

### DIFF
--- a/src/Cassette/Caching/ResourceAssetCacheValidator.cs
+++ b/src/Cassette/Caching/ResourceAssetCacheValidator.cs
@@ -1,76 +1,35 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 
 namespace Cassette.Caching
 {
     public class ResourceAssetCacheValidator : IAssetCacheValidator
     {
-        /// <summary>
-        /// Mapping of resource file name to assembly
-        /// </summary>
-        static readonly IDictionary<string, Assembly> resourceAssemblyMap;
-
-        static ResourceAssetCacheValidator()
+        public ResourceAssetCacheValidator(BundleCollection bundles)
         {
-            resourceAssemblyMap = FindAllResources();
+            this.bundles = bundles;
         }
 
-        /// <summary>
-        /// Find all the resources in all assemblies in the current AppDomain
-        /// </summary>
-        /// <returns>Resources and their associated assembly</returns>
-        private static IDictionary<string, Assembly> FindAllResources()
-        {
-            var resourcesMap = new Dictionary<string, Assembly>();
-            
-            var resources =
-                from assembly in AppDomain.CurrentDomain.GetAssemblies()
-                where IsValidResourceAssembly(assembly)
-                from resource in assembly.GetManifestResourceNames()
-                select new { Assembly = assembly, ResourceName = resource };
-
-            // Duplicate keys shouldn't occur, but ensure they don't cause any errors!
-            foreach (var resource in resources)
-            {
-                resourcesMap[resource.ResourceName] = resource.Assembly;
-            }
-
-            return resourcesMap;
-        }
-
-        /// <summary>
-        /// Determines whether the specified assembly should be treated as a valid assembly for 
-        /// embedded resources in Cassette
-        /// </summary>
-        /// <param name="assembly">Assembly to check</param>
-        /// <returns><c>true</c> if it should be counted</returns>
-        private static bool IsValidResourceAssembly(Assembly assembly)
-        {
-            return
-                // Exclude dynamic assemblies
-                !assembly.IsDynamic
-                // Exclude system assemblies
-                && assembly.FullName != "System"
-                && assembly.FullName != "mscorlib"
-                && !assembly.FullName.StartsWith("System.")
-                && !assembly.FullName.StartsWith("Microsoft.");
-        }
+        readonly BundleCollection bundles;
 
         public bool IsValid(string assetPath, DateTime asOfDateTime)
         {
-            Assembly assembly;
-            resourceAssemblyMap.TryGetValue(assetPath.Replace("~/", string.Empty), out assembly);
+            using (bundles.GetReadLock())
+            {
+                Bundle bundle;
+                IAsset asset;
 
-            // If we're not sure what assembly this file belongs to, just assume the cache is fine
-            if (assembly == null)
-                return true;
+				if (!bundles.TryGetAssetByPath(assetPath, out asset, out bundle))
+					return false;
 
-            // Check the last modified date of the assembly
-            var lastModified = File.GetLastWriteTimeUtc(assembly.Location);
-            return lastModified <= asOfDateTime;
+                var resourceAsset = asset as ResourceAsset;
+                if (resourceAsset == null)
+                    return true;
+
+                var lastModified = File.GetLastWriteTimeUtc(resourceAsset.Assembly.Location);
+                return lastModified <= asOfDateTime;
+            }
+
         }
     }
 }

--- a/src/Cassette/Caching/ResourceAssetCacheValidator.cs
+++ b/src/Cassette/Caching/ResourceAssetCacheValidator.cs
@@ -1,12 +1,76 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace Cassette.Caching
 {
     public class ResourceAssetCacheValidator : IAssetCacheValidator
     {
+        /// <summary>
+        /// Mapping of resource file name to assembly
+        /// </summary>
+        static readonly IDictionary<string, Assembly> resourceAssemblyMap;
+
+        static ResourceAssetCacheValidator()
+        {
+            resourceAssemblyMap = FindAllResources();
+        }
+
+        /// <summary>
+        /// Find all the resources in all assemblies in the current AppDomain
+        /// </summary>
+        /// <returns>Resources and their associated assembly</returns>
+        private static IDictionary<string, Assembly> FindAllResources()
+        {
+            var resourcesMap = new Dictionary<string, Assembly>();
+            
+            var resources =
+                from assembly in AppDomain.CurrentDomain.GetAssemblies()
+                where IsValidResourceAssembly(assembly)
+                from resource in assembly.GetManifestResourceNames()
+                select new { Assembly = assembly, ResourceName = resource };
+
+            // Duplicate keys shouldn't occur, but ensure they don't cause any errors!
+            foreach (var resource in resources)
+            {
+                resourcesMap[resource.ResourceName] = resource.Assembly;
+            }
+
+            return resourcesMap;
+        }
+
+        /// <summary>
+        /// Determines whether the specified assembly should be treated as a valid assembly for 
+        /// embedded resources in Cassette
+        /// </summary>
+        /// <param name="assembly">Assembly to check</param>
+        /// <returns><c>true</c> if it should be counted</returns>
+        private static bool IsValidResourceAssembly(Assembly assembly)
+        {
+            return
+                // Exclude dynamic assemblies
+                !assembly.IsDynamic
+                // Exclude system assemblies
+                && assembly.FullName != "System"
+                && assembly.FullName != "mscorlib"
+                && !assembly.FullName.StartsWith("System.")
+                && !assembly.FullName.StartsWith("Microsoft.");
+        }
+
         public bool IsValid(string assetPath, DateTime asOfDateTime)
         {
-            return true;
+            Assembly assembly;
+            resourceAssemblyMap.TryGetValue(assetPath.Replace("~/", string.Empty), out assembly);
+
+            // If we're not sure what assembly this file belongs to, just assume the cache is fine
+            if (assembly == null)
+                return true;
+
+            // Check the last modified date of the assembly
+            var lastModified = File.GetLastWriteTimeUtc(assembly.Location);
+            return lastModified <= asOfDateTime;
         }
     }
 }

--- a/src/Cassette/Caching/ResourceAssetCacheValidator.cs
+++ b/src/Cassette/Caching/ResourceAssetCacheValidator.cs
@@ -19,8 +19,8 @@ namespace Cassette.Caching
                 Bundle bundle;
                 IAsset asset;
 
-				if (!bundles.TryGetAssetByPath(assetPath, out asset, out bundle))
-					return false;
+                if (!bundles.TryGetAssetByPath(assetPath, out asset, out bundle))
+                    return false;
 
                 var resourceAsset = asset as ResourceAsset;
                 if (resourceAsset == null)

--- a/src/Cassette/ResourceAsset.cs
+++ b/src/Cassette/ResourceAsset.cs
@@ -86,5 +86,10 @@ namespace Cassette
         {
             get { return typeof(ResourceAssetCacheValidator); }
         }
+
+        public Assembly Assembly
+        {
+            get { return this.assembly; }
+        }
     }
 }


### PR DESCRIPTION
Implements proper cache validation for resource assets, based on last modified date of assembly. I have updated it to use BundleCollection.TryGetAssetByPath to get the asset, then get the assembly from there.

---

Old information from original commit (c7ea979):
Not sure if this is the best approach; the IAssetCacheValidator doesn't know which assembly the resource belongs to, so it creates a dictionary of resource name to assembly name and uses that to look up the correct assembly. This isn't foolproof and may not work properly in every scenario.
