### PR TITLE
Add support for testing templates to the Jasmine plugin

### DIFF
--- a/src/Cassette.Aspnet.Jasmine/PageHandler.cs
+++ b/src/Cassette.Aspnet.Jasmine/PageHandler.cs
@@ -55,6 +55,7 @@ namespace Cassette.Aspnet.Jasmine
             var html = Properties.Resources.runner;
             html = InsertStylesheetsIntoHtml(html);
             html = InsertScriptsIntoHtml(html);
+            html = InsertTemplatesIntoHtml(html);
             return html;
         }
 
@@ -68,6 +69,12 @@ namespace Cassette.Aspnet.Jasmine
         {
             var scripts = Bundles.RenderScripts().ToHtmlString();
             return html.Replace("$scripts$", scripts);
+        }
+
+        string InsertTemplatesIntoHtml(string html)
+        {
+            var templates = Bundles.RenderHtmlTemplates().ToHtmlString();
+            return html.Replace("$templates$", templates);
         }
 
         public bool IsReusable

--- a/src/Cassette.Aspnet.Jasmine/runner.htm
+++ b/src/Cassette.Aspnet.Jasmine/runner.htm
@@ -4,6 +4,7 @@
     <title>Jasmine Spec Runner</title>
     $styles$
     $scripts$
+    $templates$
 </head>
 <body>
 </body>


### PR DESCRIPTION
Although I try to avoid it, there is sometimes enough logic in HTML templates to make writing some quick tests for them worthwhile, which I'd like to do using Jasmine tests. This change adds the HTML bundles to the Jasmine test runner page too, so that tests can access referenced HTML.
