### PR TITLE
In some contexts the response from is not properly cacheable

### DIFF
--- a/src/Cassette.Aspnet/RawFileRequestRewriter.cs
+++ b/src/Cassette.Aspnet/RawFileRequestRewriter.cs
@@ -155,6 +155,7 @@ namespace Cassette.Aspnet
             response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
             response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
             response.Cache.SetETag(actualETag);
+            response.Cache.SetSlidingExpiration(true);
         }
 
         void SendNotModified(HttpResponseBase response) {


### PR DESCRIPTION
In some IIS configurations, the cassette response is not properly cacheable.

Using `response.Cache.SetSlidingExpiration(true);` makes it work and it should not have any adverse effect.

Fix inspired by this [page](http://geekswithblogs.net/cicorias/archive/2011/03/14/differences-when-running-with-outputcache-managed-module-under-asp.net-iis7.x.aspx)
