### PR TITLE
Add option to isolate storage container to AppDomain rather than to assembly.

### DIFF
--- a/src/Cassette.Aspnet/IsolatedStorageContainer.cs
+++ b/src/Cassette.Aspnet/IsolatedStorageContainer.cs
@@ -14,10 +14,15 @@ namespace Cassette.Aspnet
         public IsolatedStorageContainer(bool perDomain)
         {
             // ReSharper disable ConvertClosureToMethodGroup because would cause this problem: http://stackoverflow.com/q/9113791/7011
-            LazyStorage = perDomain ?
-                new DisposableLazy<IsolatedStorageFile>(() => IsolatedStorageFile.GetMachineStoreForDomain()) : 
-                new DisposableLazy<IsolatedStorageFile>(() => IsolatedStorageFile.GetMachineStoreForAssembly());
+            LazyStorage = new DisposableLazy<IsolatedStorageFile>(() => CreateIsolatedStorage(perDomain));
             // ReSharper restore ConvertClosureToMethodGroup
+        }
+
+        static IsolatedStorageFile CreateIsolatedStorage(bool perDomain)
+        {
+            return perDomain 
+                ? IsolatedStorageFile.GetMachineStoreForDomain() 
+                : IsolatedStorageFile.GetMachineStoreForAssembly();
         }
 
         public IsolatedStorageFile IsolatedStorageFile

--- a/src/Cassette.Aspnet/IsolatedStorageContainer.cs
+++ b/src/Cassette.Aspnet/IsolatedStorageContainer.cs
@@ -7,23 +7,25 @@ namespace Cassette.Aspnet
     /// Provides the isolated storage used by Cassette.
     /// Storage is only created on demand.
     /// </summary>
-    static class IsolatedStorageContainer
+    class IsolatedStorageContainer
     {
-        // ReSharper disable ConvertClosureToMethodGroup because would cause this problem: http://stackoverflow.com/q/9113791/7011
-        static readonly DisposableLazy<IsolatedStorageFile> LazyStorage = new DisposableLazy<IsolatedStorageFile>(() => CreateIsolatedStorage());
-        // ReSharper restore ConvertClosureToMethodGroup
+        readonly DisposableLazy<IsolatedStorageFile> LazyStorage;
 
-        static IsolatedStorageFile CreateIsolatedStorage()
+        public IsolatedStorageContainer(bool perDomain)
         {
-            return IsolatedStorageFile.GetMachineStoreForAssembly();
+            // ReSharper disable ConvertClosureToMethodGroup because would cause this problem: http://stackoverflow.com/q/9113791/7011
+            LazyStorage = perDomain ?
+                new DisposableLazy<IsolatedStorageFile>(() => IsolatedStorageFile.GetMachineStoreForDomain()) : 
+                new DisposableLazy<IsolatedStorageFile>(() => IsolatedStorageFile.GetMachineStoreForAssembly());
+            // ReSharper restore ConvertClosureToMethodGroup
         }
 
-        public static IsolatedStorageFile IsolatedStorageFile
+        public IsolatedStorageFile IsolatedStorageFile
         {
             get { return LazyStorage.Value; }
         }
 
-        public static void Dispose()
+        public void Dispose()
         {
             LazyStorage.Dispose();
         }

--- a/src/Cassette.Aspnet/WebHostSettingsConfiguration.cs
+++ b/src/Cassette.Aspnet/WebHostSettingsConfiguration.cs
@@ -42,7 +42,8 @@ namespace Cassette.Aspnet
             var path = configurationSection.CacheDirectory;
             if (string.IsNullOrEmpty(path))
             {
-                return new IsolatedStorageDirectory(() => IsolatedStorageContainer.IsolatedStorageFile);
+                var container = new IsolatedStorageContainer(configurationSection.IsolatedStoragePerDomain);
+                return new IsolatedStorageDirectory(() => container.IsolatedStorageFile);
             }
             else if (Path.IsPathRooted(path))
             {

--- a/src/Cassette/CassetteConfigurationSection.cs
+++ b/src/Cassette/CassetteConfigurationSection.cs
@@ -31,5 +31,12 @@ namespace Cassette
             get { return (string)this["cacheDirectory"]; }
             set { this["cacheDirectory"] = value; }
         }
+
+        [ConfigurationProperty("isolatedStoragePerDomain", DefaultValue = false)]
+        public bool IsolatedStoragePerDomain
+        {
+            get { return (bool)this["isolatedStoragePerDomain"]; }
+            set { this["isolatedStoragePerDomain"] = value; }
+        }
     }
 }

--- a/src/Website/Views/Documentation/v2/WebConfig.cshtml
+++ b/src/Website/Views/Documentation/v2/WebConfig.cshtml
@@ -15,7 +15,8 @@
         debug="true|false"
         rewriteHtml="true|false"
         allowRemoteDiagnostics="true|false"
-        cacheDirectory="directory-path" /&gt;
+        cacheDirectory="directory-path" 
+        isolatedStoragePerDomain="true|false" /&gt;
         
     ...
 &lt;/configuration&gt;</code></pre>
@@ -36,4 +37,14 @@
 
 <h2>The <code>cacheDirectory</code> property</h2>
 <p>Configures where Cassette will cache optimized bundle content.</p>
-<p>When empty (the default) Isolated Storage is used. Otherwise, this should be a file system path. It can be relative to the web application's root directory.</p>
+<p>
+	When empty (the default) <a href="http://msdn.microsoft.com/en-us/library/3ak841sy.aspx">Isolated Storage</a> is used. Otherwise, this should be a file system 
+	path. It can be relative to the web application's root directory.
+</p>
+
+<h2>The <code>isolatedStoragePerDomain</code> property</h2>
+<p>
+	Configures whether Isolated Storage should be isolated to the AppDomain (<code>true</code>) or to the assembly (<code>false</code>). This should normally be 
+	<code>false</code> unless you are using the same assembly with the same path in multiple websites (for example, you have the one application running in several
+	different virtual directories). Defaults to <code>false</code>.
+</p>


### PR DESCRIPTION
This fixes the _System.IO.IOException: The process cannot access the file 'manifest.xml' because it is being used by another process._ issue when the one ASP.NET application is mapped to more than one IIS application, and two worker processes try to rebuild the bundles at the same time.

This is the original exception:

```
System.Exception: Bundle collection rebuild failed. See inner exception for details. ---> System.IO.IOException: The process cannot access the file 'manifest.xml' because it is being used by another process.
at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath)
at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy, Boolean useLongPath)
at System.IO.IsolatedStorage.IsolatedStorageFileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, IsolatedStorageFile isf)
at System.IO.IsolatedStorage.IsolatedStorageFileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, IsolatedStorageFile isf)
at System.IO.IsolatedStorage.IsolatedStorageFile.OpenFile(String path, FileMode mode, FileAccess access, FileShare share)
at Cassette.IO.IsolatedStorageFile.Open(FileMode mode, FileAccess access, FileShare fileShare)
at Cassette.Caching.BundleCollectionCacheWriter.OpenManifestFileForWriting()
at Cassette.Caching.BundleCollectionCacheWriter.WriteManifestFile(Manifest manifest)
at Cassette.Caching.BundleCollectionCache.Write(Manifest manifest)
at Cassette.CacheAwareBundleCollectionInitializer.WriteToCache()
at Cassette.CacheAwareBundleCollectionInitializer.Initialize(BundleCollection bundleCollection)
at Cassette.RuntimeBundleCollectionInitializer.Initialize(BundleCollection bundles)
at Cassette.ExceptionCatchingBundleCollectionInitializer.Initialize(BundleCollection bundleCollection)
--- End of inner exception stack trace ---
```
