### PR TITLE
all exceptions now follow the framework guidelines

### DIFF
--- a/src/Cassette.CoffeeScript/CoffeeScriptCompileException.cs
+++ b/src/Cassette.CoffeeScript/CoffeeScriptCompileException.cs
@@ -1,12 +1,19 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Cassette.Scripts
 {
+    [Serializable]
     public class CoffeeScriptCompileException : Exception
     {
         public CoffeeScriptCompileException(string message, string sourcePath, Exception innerException) : base(message, innerException)
         {
             SourcePath = sourcePath;
+        }
+
+        protected CoffeeScriptCompileException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         public string SourcePath { get; private set; }

--- a/src/Cassette.Less/LessCompileException.cs
+++ b/src/Cassette.Less/LessCompileException.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Cassette.Stylesheets
 {
+    [Serializable]
     public class LessCompileException : Exception
     {
         public LessCompileException(string message, Exception innerException)
@@ -11,6 +13,11 @@ namespace Cassette.Stylesheets
 
         public LessCompileException(string message)
             : base(message)
+        {
+        }
+
+        protected LessCompileException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/Cassette.Spriting/Spritastic/SpriteException.cs
+++ b/src/Cassette.Spriting/Spritastic/SpriteException.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Cassette.Spriting.Spritastic
 {
+    [Serializable]
     class SpriteException : ApplicationException
     {
         public SpriteException(string message, Exception innerException)
@@ -12,6 +14,11 @@ namespace Cassette.Spriting.Spritastic
         public SpriteException(string cssRule, string message, Exception innerException) : base(message, innerException)
         {
             CssRule = cssRule;
+        }
+
+        protected SpriteException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
 
         public string CssRule { get; private set; }

--- a/src/Cassette.Spriting/Spritastic/Utilities/OptimizationException.cs
+++ b/src/Cassette.Spriting/Spritastic/Utilities/OptimizationException.cs
@@ -1,10 +1,23 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Cassette.Spriting.Spritastic.Utilities
 {
+    [Serializable]
     class OptimizationException : Exception
     {
         public OptimizationException(string message) : base(message)
+        {
+        }
+
+        public OptimizationException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            
+        }
+
+        protected OptimizationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/Cassette/AssetReferenceException.cs
+++ b/src/Cassette/AssetReferenceException.cs
@@ -1,10 +1,23 @@
 ﻿using System;
+using System.Runtime.Serialization;
 
 namespace Cassette
 {
+    [Serializable]
     public class AssetReferenceException : Exception
     {
         public AssetReferenceException(string message) : base(message)
+        {
+        }
+
+        public AssetReferenceException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+            
+        }
+
+        protected AssetReferenceException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
     }

--- a/src/Cassette/CassetteDeserializationException.cs
+++ b/src/Cassette/CassetteDeserializationException.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace Cassette
 {
+    [Serializable]
     class CassetteDeserializationException : Exception
     {
         public CassetteDeserializationException(string message) : base(message)
@@ -10,6 +12,11 @@ namespace Cassette
 
         public CassetteDeserializationException(string message, Exception innerException) : base(message, innerException)
         {   
+        }
+
+        protected CassetteDeserializationException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
         }
     }
 }

--- a/src/Cassette/Interop/ActiveScriptException.cs
+++ b/src/Cassette/Interop/ActiveScriptException.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Runtime.InteropServices.ComTypes;
+using System.Runtime.Serialization;
 
 namespace Cassette.Interop
 {
-    public sealed class ActiveScriptException : Exception
+    [Serializable]
+    public class ActiveScriptException : Exception
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ActiveScriptException"/> class.
@@ -13,6 +15,11 @@ namespace Cassette.Interop
         /// <param name="message">The message.</param>
         ActiveScriptException(string message)
             : base(message)
+        {
+        }
+
+        protected ActiveScriptException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
         {
         }
 


### PR DESCRIPTION
addresses #359. these exceptions must be able to cross an appdomain boundary to aid in debugging
