### PR TITLE
Reinitialize bundles automatically in the event of a compile failure

### DIFF
--- a/src/Cassette.Aspnet.Jasmine.UnitTests/JasmineBundleConfiguration.cs
+++ b/src/Cassette.Aspnet.Jasmine.UnitTests/JasmineBundleConfiguration.cs
@@ -18,7 +18,7 @@ namespace Cassette.Aspnet.Jasmine
             var stylesheetBundleFactory = new StylesheetBundleFactory(() => Mock.Of<IBundlePipeline<StylesheetBundle>>());
             var configuration = new JasmineBundleConfiguration(scriptBundleFactory, stylesheetBundleFactory);
             var settings = new CassetteSettings();
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
 
             configuration.Configure(bundles);
         }

--- a/src/Cassette.Aspnet.UnitTests/AssetRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/AssetRequestHandler.cs
@@ -40,7 +40,7 @@ namespace Cassette.Aspnet
             response.SetupGet(r => r.Cache).Returns(cache.Object);
             request.SetupGet(r => r.Headers).Returns(requestHeaders);
 
-            bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             handler = new AssetRequestHandler(requestContext, bundles);
         }
 

--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -46,7 +46,7 @@ namespace Cassette.Aspnet
             request.SetupGet(x => x.RawUrl).Returns("~/010203/test");
 
             var settings = new CassetteSettings();
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
         }
 
         internal BundleRequestHandler<TestableBundle> CreateRequestHandler()

--- a/src/Cassette.Aspnet.UnitTests/DiagnosticRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/DiagnosticRequestHandler.cs
@@ -28,7 +28,7 @@ namespace Cassette.Aspnet
             httpContext.SetupGet(c => c.Response).Returns(response.Object);
             var requestContext = new RequestContext(httpContext.Object, new RouteData());
             settings = new CassetteSettings();
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             var urlGenerator = Mock.Of<IUrlGenerator>();
             rebuilder = new Mock<IBundleCacheRebuilder>();
             helper = new Mock<IBundlesHelper>();

--- a/src/Cassette.UnitTests/BundleCollection.BuildReferences.cs
+++ b/src/Cassette.UnitTests/BundleCollection.BuildReferences.cs
@@ -10,7 +10,7 @@ namespace Cassette
 
         public BundleCollection_BuildReferences()
         {
-            var bundleCollection = collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            var bundleCollection = collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
         }
 
         [Fact]

--- a/src/Cassette.UnitTests/BundleCollection.Equals.cs
+++ b/src/Cassette.UnitTests/BundleCollection.Equals.cs
@@ -62,7 +62,7 @@ namespace Cassette
 
         BundleCollection EmptyBundleCollection()
         {
-            return new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            return new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
         }
     }
 }

--- a/src/Cassette.UnitTests/BundleCollection.FindBundlesContainingPath.cs
+++ b/src/Cassette.UnitTests/BundleCollection.FindBundlesContainingPath.cs
@@ -11,7 +11,7 @@ namespace Cassette
         public void FindBundleContainingPathOfBundleReturnsTheBundle()
         {
             var expectedBundle = new TestableBundle("~/test");
-            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>())
+            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>())
             {
                 expectedBundle
             };
@@ -23,7 +23,7 @@ namespace Cassette
         public void FindBundleContainingPathOfBundleWherePathIsMissingRootPrefixReturnsTheBundle()
         {
             var expectedBundle = new TestableBundle("~/test");
-            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>())
+            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>())
             {
                 expectedBundle
             };
@@ -34,7 +34,7 @@ namespace Cassette
         [Fact]
         public void FindBundleContainingPathWithWrongPathReturnsNull()
         {
-            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>())
+            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>())
             {
                 new TestableBundle("~/test")
             };
@@ -50,7 +50,7 @@ namespace Cassette
             AssetAcceptsVisitor(asset);
             asset.SetupGet(a => a.Path).Returns("~/test/test.js");
             expectedBundle.Assets.Add(asset.Object);
-            var bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>())
+            var bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>())
             {
                 expectedBundle
             };

--- a/src/Cassette.UnitTests/BundleCollection.SortBundles.cs
+++ b/src/Cassette.UnitTests/BundleCollection.SortBundles.cs
@@ -182,7 +182,7 @@ namespace Cassette
 
         BundleCollection CreateBundleCollection(IEnumerable<Bundle> bundles)
         {
-            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             foreach (var bundle in bundles)
             {
                 collection.Add(bundle);

--- a/src/Cassette.UnitTests/BundleCollection.cs
+++ b/src/Cassette.UnitTests/BundleCollection.cs
@@ -10,7 +10,7 @@ namespace Cassette
 {
     public class BundleCollection_Tests
     {
-        readonly BundleCollection bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+        readonly BundleCollection bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
 
         [Fact]
         public void GivenBundleAdded_WhenGetByAppRelativePath_ThenBundleReturned()

--- a/src/Cassette.UnitTests/BundleCollectionTestsBase.cs
+++ b/src/Cassette.UnitTests/BundleCollectionTestsBase.cs
@@ -48,7 +48,7 @@ namespace Cassette
                 .Setup(p => p.GetFileSearch(It.IsAny<Type>()))
                 .Returns(fileSearch.Object);
 
-            bundles = new BundleCollection(settings, fileSearchProvider.Object, bundleFactoryProvider.Object);
+            bundles = new BundleCollection(settings, fileSearchProvider.Object, bundleFactoryProvider.Object, Mock.Of<IBundleCollectionInitializer>());
         }
 
         public void Dispose()

--- a/src/Cassette.UnitTests/Caching/BundleCollectionCache.Write.cs
+++ b/src/Cassette.UnitTests/Caching/BundleCollectionCache.Write.cs
@@ -22,7 +22,7 @@ namespace Cassette.Caching
             path = new TempDirectory();
             directory = new FileSystemDirectory(path);
 
-            var bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            var bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             scriptBundle = new Mock<ScriptBundle>("~/test1");
             scriptBundle.CallBase = true;
             scriptBundle.Object.Hash = new byte[] { 1, 2, 3 };

--- a/src/Cassette.UnitTests/ExceptionCatchingBundleCollectionInitializer.cs
+++ b/src/Cassette.UnitTests/ExceptionCatchingBundleCollectionInitializer.cs
@@ -13,7 +13,7 @@ namespace Cassette
 
         public ExceptionCatchingBundleCollectionInitializer_WhereInitializerImplementationDoesNotThrowException()
         {
-            bundleCollection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundleCollection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
 
             initializerThatThrows = new Mock<IBundleCollectionInitializer>();
 
@@ -46,7 +46,7 @@ namespace Cassette
 
         public ExceptionCatchingBundleCollectionInitializer_WhereInitializerImplementationThrowsException()
         {
-            bundleCollection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundleCollection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             bundleCollection.Add(new TestableBundle("~")); // Add a bundle so we can check the collection gets cleared.
 
             initializerThatThrows = new Mock<IBundleCollectionInitializer>();

--- a/src/Cassette.UnitTests/FileAccessAuthorization.cs
+++ b/src/Cassette.UnitTests/FileAccessAuthorization.cs
@@ -15,7 +15,7 @@ namespace Cassette
         {
             configuration = new Mock<IConfiguration<IFileAccessAuthorization>>();
             var configurations = new[] { configuration.Object };
-            bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
 
             authorization = new FileAccessAuthorization(configurations, bundles);
         }

--- a/src/Cassette.UnitTests/FileSystemWatchingBundleRebuilder.cs
+++ b/src/Cassette.UnitTests/FileSystemWatchingBundleRebuilder.cs
@@ -27,7 +27,7 @@ namespace Cassette
                 CacheDirectory = new FileSystemDirectory(Path.Combine(tempDirectory, "cache")),
                 IsFileSystemWatchingEnabled = true
             };
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             bundleConfiguration = new Mock<IConfiguration<BundleCollection>>();
 
             var bundle = new TestableBundle("~");

--- a/src/Cassette.UnitTests/ReferenceBuilder.cs
+++ b/src/Cassette.UnitTests/ReferenceBuilder.cs
@@ -16,7 +16,7 @@ namespace Cassette
         protected ReferenceBuilder_Reference_TestBase()
         {
             settings = new CassetteSettings();
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             bundleFactoryProvider = new Mock<IBundleFactoryProvider>();
             placeholderTracker = new Mock<IPlaceholderTracker>();
             builder = new ReferenceBuilder(bundles, placeholderTracker.Object, bundleFactoryProvider.Object, settings);

--- a/src/Cassette.Views.UnitTests/Bundles.cs
+++ b/src/Cassette.Views.UnitTests/Bundles.cs
@@ -23,7 +23,7 @@ namespace Cassette.Views
             urlGenerator = new Mock<IUrlGenerator>();
             referenceBuilder = new Mock<IReferenceBuilder>();
             settings = new CassetteSettings();
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             fileAccessAuthorization = new Mock<IFileAccessAuthorization>();
             bundleCacheRebuilder = new Mock<IBundleCacheRebuilder>();
             Bundles.Helper = new BundlesHelper(bundles, settings, urlGenerator.Object, () => referenceBuilder.Object, fileAccessAuthorization.Object, bundleCacheRebuilder.Object, new SimpleJsonSerializer());

--- a/src/Cassette.Views.UnitTests/BundlesHelper.cs
+++ b/src/Cassette.Views.UnitTests/BundlesHelper.cs
@@ -16,7 +16,7 @@ namespace Cassette.Views
         public BundlesHelper_Tests()
         {
             settings = new CassetteSettings();
-            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             referenceBuilder = new Mock<IReferenceBuilder>();
             var urlModifier = new VirtualDirectoryPrepender("/");
             var urlGenerator = new UrlGenerator(urlModifier, new FakeFileSystem(), "cassette.axd/");

--- a/src/Cassette.Views.UnitTests/Bundles_FileUrl_Tests.cs
+++ b/src/Cassette.Views.UnitTests/Bundles_FileUrl_Tests.cs
@@ -36,7 +36,7 @@ namespace Cassette.Views
             fileAccessAuthorization.Setup(a => a.CanAccess("~/test.png")).Returns(true);
 
             var referenceBuilder = new Mock<IReferenceBuilder>();
-            var bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+            var bundles = new BundleCollection(settings, Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
             var bundleCacheRebuilder = new Mock<IBundleCacheRebuilder>();
             Bundles.Helper = new BundlesHelper(bundles, settings, urlGenerator.Object, () => referenceBuilder.Object, fileAccessAuthorization.Object, bundleCacheRebuilder.Object, new SimpleJsonSerializer());
         }

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -23,18 +23,18 @@ namespace Cassette
         readonly CassetteSettings settings;
         readonly IFileSearchProvider fileSearchProvider;
         readonly IBundleFactoryProvider bundleFactoryProvider; 
-		readonly IBundleCollectionInitializer bundleCollectionInitializer;
+        readonly IBundleCollectionInitializer bundleCollectionInitializer;
         readonly ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         Dictionary<Bundle, HashedSet<Bundle>> bundleImmediateReferences;
         Exception initializationException;
-	   
+       
 
-	    public BundleCollection(CassetteSettings settings, IFileSearchProvider fileSearchProvider, IBundleFactoryProvider bundleFactoryProvider, IBundleCollectionInitializer bundleCollectionInitializer)
+        public BundleCollection(CassetteSettings settings, IFileSearchProvider fileSearchProvider, IBundleFactoryProvider bundleFactoryProvider, IBundleCollectionInitializer bundleCollectionInitializer)
         {
-		    this.settings = settings;
+            this.settings = settings;
             this.fileSearchProvider = fileSearchProvider;
             this.bundleFactoryProvider = bundleFactoryProvider;
-			this.bundleCollectionInitializer = bundleCollectionInitializer;
+            this.bundleCollectionInitializer = bundleCollectionInitializer;
         }
 
         public event EventHandler<BundleCollectionChangedEventArgs> Changed = delegate { };
@@ -66,18 +66,18 @@ namespace Cassette
             {
                 readerWriterLock.ExitReadLock();
 
-				// we attempt to re-initialize the bundle collection if the original init failed
-				// this prevents unintentional "caching" of compiler errors for things like Less or Compass until the AppDomain recycles
-	            lock (bundleCollectionInitializer)
-	            {
-		            bundleCollectionInitializer.Initialize(this);
-	            }
+                // we attempt to re-initialize the bundle collection if the original init failed
+                // this prevents unintentional "caching" of compiler errors for things like Less or Compass until the AppDomain recycles
+                lock (bundleCollectionInitializer)
+                {
+                    bundleCollectionInitializer.Initialize(this);
+                }
 
-	            if(InitializationException != null)
-					throw new Exception("Bundle collection rebuild failed. See inner exception for details.", InitializationException);
+                if(InitializationException != null)
+                    throw new Exception("Bundle collection rebuild failed. See inner exception for details.", InitializationException);
 
-				// if we fixed the build error we need that lock back!
-				readerWriterLock.EnterReadLock();
+                // if we fixed the build error we need that lock back!
+                readerWriterLock.EnterReadLock();
             }
 
             return new DelegatingDisposable(() => readerWriterLock.ExitReadLock());

--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -22,16 +22,19 @@ namespace Cassette
         readonly List<Bundle> bundles = new List<Bundle>();
         readonly CassetteSettings settings;
         readonly IFileSearchProvider fileSearchProvider;
-        readonly IBundleFactoryProvider bundleFactoryProvider;
+        readonly IBundleFactoryProvider bundleFactoryProvider; 
+		readonly IBundleCollectionInitializer bundleCollectionInitializer;
         readonly ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         Dictionary<Bundle, HashedSet<Bundle>> bundleImmediateReferences;
         Exception initializationException;
-        
-        public BundleCollection(CassetteSettings settings, IFileSearchProvider fileSearchProvider, IBundleFactoryProvider bundleFactoryProvider)
+	   
+
+	    public BundleCollection(CassetteSettings settings, IFileSearchProvider fileSearchProvider, IBundleFactoryProvider bundleFactoryProvider, IBundleCollectionInitializer bundleCollectionInitializer)
         {
-            this.settings = settings;
+		    this.settings = settings;
             this.fileSearchProvider = fileSearchProvider;
             this.bundleFactoryProvider = bundleFactoryProvider;
+			this.bundleCollectionInitializer = bundleCollectionInitializer;
         }
 
         public event EventHandler<BundleCollectionChangedEventArgs> Changed = delegate { };
@@ -62,7 +65,19 @@ namespace Cassette
             if (InitializationException != null)
             {
                 readerWriterLock.ExitReadLock();
-                throw new Exception("Bundle collection rebuild failed. See inner exception for details.", InitializationException);
+
+				// we attempt to re-initialize the bundle collection if the original init failed
+				// this prevents unintentional "caching" of compiler errors for things like Less or Compass until the AppDomain recycles
+	            lock (bundleCollectionInitializer)
+	            {
+		            bundleCollectionInitializer.Initialize(this);
+	            }
+
+	            if(InitializationException != null)
+					throw new Exception("Bundle collection rebuild failed. See inner exception for details.", InitializationException);
+
+				// if we fixed the build error we need that lock back!
+				readerWriterLock.EnterReadLock();
             }
 
             return new DelegatingDisposable(() => readerWriterLock.ExitReadLock());


### PR DESCRIPTION
This pull request addresses [issue #355](https://github.com/andrewdavey/cassette/issues/355)

If a compiler, such as SASS or Less or Compass had a compile error previously the error would become "stuck" in the AppDomain and no further attempts to rebuild the bundle would be made until the AppDomain recycled.

That's less than optimal if you tweak the file to fix it and Cassette says it's not fixed.

This changes the code to re-initialize the bundle once if an exception occurred during the initial rebuilding, which allows compile errors to be reevaluated without a rebuild.
