### PR TITLE
Fixed an issue where the build task would fail if the destination files ...

### DIFF
--- a/src/Cassette.MSBuild/RawFileCopier.cs
+++ b/src/Cassette.MSBuild/RawFileCopier.cs
@@ -46,7 +46,12 @@ namespace Cassette.MSBuild
         void CopyFile(string absoluteSourceFilename, string outputPath)
         {
             EnsureFilenameDirectoryExists(outputPath);
-            File.Copy(absoluteSourceFilename, outputPath);
+            // Ensure destination is not readonly
+	        if (File.Exists(outputPath))
+	        {
+	            File.SetAttributes(outputPath, FileAttributes.Normal);
+	        }
+	        File.Copy(absoluteSourceFilename, outputPath, true);
         }
 
         string CreateOutputFilename(string sourceFilename)


### PR DESCRIPTION
...are marked as read only. This is common if you are using TFS
