### PR TITLE
Support AngularJS templates

### DIFF
--- a/src/Cassette/Bundle.cs
+++ b/src/Cassette/Bundle.cs
@@ -113,7 +113,8 @@ namespace Cassette
         {
             { "text/javascript", "js" },
             { "text/css", "css" },
-            { "text/html", "htm" }
+            { "text/html", "htm" },
+            { "text/ng-template", "htm" }
         };
 
         public IEnumerable<string> References


### PR DESCRIPTION
When you develop an AngularJS app you need to set type="text/ng-template" customizing the html bundle:

``` C#
bundles.Add<HtmlTemplateBundle>("views/templates", 
                          c => { c.ContentType = "text/ng-template"; });
```

This only works in Debug. In Release you receive an exception (KeyNotFoundException) because that type isn't in the FileExtensionsByContentType Dictionary.
