### PR TITLE
Adding Compression to various places

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/AssetRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/AssetRequestHandler.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Web;
@@ -13,165 +14,225 @@ using System;
 
 namespace Cassette.Aspnet
 {
-    public class AssetRequestHandler_Tests
-    {
-        public AssetRequestHandler_Tests()
-        {            
-            var routeData = new RouteData();            
-            request = new Mock<HttpRequestBase>();
-            response = new Mock<HttpResponseBase>();
-            cache = new Mock<HttpCachePolicyBase>();
-            requestHeaders = new NameValueCollection();
+	public class AssetRequestHandler_Tests
+	{
+		public AssetRequestHandler_Tests()
+		{
+			var routeData = new RouteData();
+			request = new Mock<HttpRequestBase>();
+			response = new Mock<HttpResponseBase>();
+			cache = new Mock<HttpCachePolicyBase>();
+			requestHeaders = new NameValueCollection();
 
-            routeData.Values.Add("path", "test/asset_js");
+			routeData.Values.Add("path", "test/asset_js");
 
-            var httpContext = new Mock<HttpContextBase>();
-            httpContext.SetupGet(r => r.Response)
-                          .Returns(response.Object);
-            httpContext.SetupGet(r => r.Request)
-                          .Returns(request.Object);
-            httpContext.SetupGet(r => r.Items)
-                          .Returns(new Dictionary<string, object>());
+			var httpContext = new Mock<HttpContextBase>();
+			httpContext.SetupGet(r => r.Response)
+						  .Returns(response.Object);
+			httpContext.SetupGet(r => r.Request)
+						  .Returns(request.Object);
+			httpContext.SetupGet(r => r.Items)
+						  .Returns(new Dictionary<string, object>());
 
-            var requestContext = new RequestContext(httpContext.Object, routeData);
-            request.SetupGet(x => x.RawUrl).Returns("~/test/010203/asset.js");
+			var requestContext = new RequestContext(httpContext.Object, routeData);
+			request.SetupGet(x => x.RawUrl).Returns("~/test/010203/asset.js");
 
-            response.SetupGet(r => r.OutputStream).Returns(() => outputStream);
-            response.SetupGet(r => r.Cache).Returns(cache.Object);
-            request.SetupGet(r => r.Headers).Returns(requestHeaders);
+			response.SetupGet(r => r.OutputStream).Returns(() => outputStream);
+			response.SetupGet(r => r.Cache).Returns(cache.Object);
+			request.SetupGet(r => r.Headers).Returns(requestHeaders);
 
-            bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
-            handler = new AssetRequestHandler(requestContext, bundles);
-        }
+			bundles = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>());
+			handler = new AssetRequestHandler(requestContext, bundles);
+		}
 
-        readonly AssetRequestHandler handler;
-        readonly Mock<HttpRequestBase> request;
-        readonly Mock<HttpResponseBase> response;
-        readonly Mock<HttpCachePolicyBase> cache;
-        readonly NameValueCollection requestHeaders;
-        readonly BundleCollection bundles;
-        MemoryStream outputStream;
+		readonly AssetRequestHandler handler;
+		readonly Mock<HttpRequestBase> request;
+		readonly Mock<HttpResponseBase> response;
+		readonly Mock<HttpCachePolicyBase> cache;
+		readonly NameValueCollection requestHeaders;
+		readonly BundleCollection bundles;
+		MemoryStream outputStream;
 
-        [Fact]
-        public void GivenBundleNotFound_WhenProcessRequest_ThenNotFoundResponse()
-        {
-            bundles.Clear();
-            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest(null));
-            httpException.GetHttpCode().ShouldEqual(404);
-            response.VerifySet(r => r.StatusCode = 404);
-        }
+		[Fact]
+		public void GivenBundleNotFound_WhenProcessRequest_ThenNotFoundResponse()
+		{
+			bundles.Clear();
+			var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest(null));
+			httpException.GetHttpCode().ShouldEqual(404);
+			response.VerifySet(r => r.StatusCode = 404);
+		}
 
-        [Fact]
-        public void GivenBundleFoundButAssetIsNull_WhenProcessRequest_ThenNotFoundResponse()
-        {
-            bundles.Add(new TestableBundle("~/test"));
-            var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest("~/test/asset.js"));
-            httpException.GetHttpCode().ShouldEqual(404);
-            response.VerifySet(r => r.StatusCode = 404);
-        }
+		[Fact]
+		public void GivenBundleFoundButAssetIsNull_WhenProcessRequest_ThenNotFoundResponse()
+		{
+			bundles.Add(new TestableBundle("~/test"));
+			var httpException = Assert.Throws<HttpException>(() => handler.ProcessRequest("~/test/asset.js"));
+			httpException.GetHttpCode().ShouldEqual(404);
+			response.VerifySet(r => r.StatusCode = 404);
+		}
 
-        [Fact]
-        public void GivenAssetExists_WhenProcessRequest_ThenMaxAgeIsSetToAYear()
-        {
-            bundles.Add(new TestableBundle("~/test")
-            {
-                ContentType = "CONTENT/TYPE"
-            });
-            var asset = new Mock<IAsset>();
-            asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
-                 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
-            asset.SetupGet(a => a.Path)
-                 .Returns("~/test/asset.js");
-            asset.Setup(a => a.OpenStream())
-                 .Returns(Stream.Null);
-            bundles.First().Assets.Add(asset.Object);
+		[Fact]
+		public void GivenAssetExists_WhenProcessRequest_ThenMaxAgeIsSetToAYear()
+		{
+			bundles.Add(new TestableBundle("~/test")
+			{
+				ContentType = "CONTENT/TYPE"
+			});
+			var asset = new Mock<IAsset>();
+			asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
+				 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
+			asset.SetupGet(a => a.Path)
+				 .Returns("~/test/asset.js");
+			asset.Setup(a => a.OpenStream())
+				 .Returns(Stream.Null);
+			bundles.First().Assets.Add(asset.Object);
 
-            using (outputStream = new MemoryStream())
-            {
-                handler.ProcessRequest("~/test/asset.js");
-            }
+			using (outputStream = new MemoryStream())
+			{
+				handler.ProcessRequest("~/test/asset.js");
+			}
 
-            cache.Verify(c => c.SetCacheability(HttpCacheability.Public));
-            cache.Verify(c => c.SetMaxAge(It.Is<TimeSpan>(t => t.Days == 365)));
-        }
+			cache.Verify(c => c.SetCacheability(HttpCacheability.Public));
+			cache.Verify(c => c.SetMaxAge(It.Is<TimeSpan>(t => t.Days == 365)));
+		}
 
-        [Fact]
-        public void GivenAssetExists_WhenProcessRequest_ThenResponseContentTypeIsBundleContentType()
-        {
-            bundles.Add(new TestableBundle("~/test")
-            {
-                ContentType = "CONTENT/TYPE"
-            });
-            var asset = new Mock<IAsset>();
-            asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
-                 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
-            asset.SetupGet(a => a.Path)
-                 .Returns("~/test/asset.js");
-            asset.Setup(a => a.OpenStream())
-                 .Returns(Stream.Null);
-            bundles.First().Assets.Add(asset.Object);
+		[Fact]
+		public void GivenAssetExists_WhenProcessRequest_ThenResponseContentTypeIsBundleContentType()
+		{
+			bundles.Add(new TestableBundle("~/test")
+			{
+				ContentType = "CONTENT/TYPE"
+			});
+			var asset = new Mock<IAsset>();
+			asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
+				 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
+			asset.SetupGet(a => a.Path)
+				 .Returns("~/test/asset.js");
+			asset.Setup(a => a.OpenStream())
+				 .Returns(Stream.Null);
+			bundles.First().Assets.Add(asset.Object);
 
-            using (outputStream = new MemoryStream())
-            {
-                handler.ProcessRequest("~/test/asset.js");
-            }
+			using (outputStream = new MemoryStream())
+			{
+				handler.ProcessRequest("~/test/asset.js");
+			}
 
-            response.VerifySet(r => r.ContentType = "CONTENT/TYPE");
-        }
+			response.VerifySet(r => r.ContentType = "CONTENT/TYPE");
+		}
 
-        [Fact]
-        public void GivenAssetExists_WhenProcessRequest_ThenResponseOutputIsAssetContent()
-        {
-            bundles.Add(new TestableBundle("~/test")
-            {
-                ContentType = "CONTENT/TYPE"
-            });
-            var asset = new Mock<IAsset>();
-            asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
-                 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
-            asset.SetupGet(a => a.Path)
-                 .Returns("~/test/asset.js");
-            asset.Setup(a => a.OpenStream())
-                 .Returns(() => "output".AsStream());
-            bundles.First().Assets.Add(asset.Object);
+		[Fact]
+		public void GivenAssetExists_WhenProcessRequest_ThenResponseOutputIsAssetContent()
+		{
+			bundles.Add(new TestableBundle("~/test")
+			{
+				ContentType = "CONTENT/TYPE"
+			});
+			var asset = new Mock<IAsset>();
+			asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
+				 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
+			asset.SetupGet(a => a.Path)
+				 .Returns("~/test/asset.js");
+			asset.Setup(a => a.OpenStream())
+				 .Returns(() => "output".AsStream());
+			bundles.First().Assets.Add(asset.Object);
 
-            using (outputStream = new MemoryStream())
-            {
-                handler.ProcessRequest("~/test/asset.js");
+			using (outputStream = new MemoryStream())
+			{
+				handler.ProcessRequest("~/test/asset.js");
 
-                Encoding.UTF8.GetString(outputStream.ToArray()).ShouldEqual("output");
-            }
-        }
+				Encoding.UTF8.GetString(outputStream.ToArray()).ShouldEqual("output");
+			}
+		}
 
-        [Fact]
-        public void GivenRequestWithMatchingETag_WhenProcessRequest_ThenReturn304NotModifiedResponse()
-        {
-            bundles.Add(new TestableBundle("~/test"));
-            var asset = new StubAsset("~/test/asset.js", hash: new byte[] { 1, 2, 3 });
-            bundles.First().Assets.Add(asset);
+		[Fact]
+		public void GivenAssetExists_WhenProcessRequestWithEncodingDeflate_ThenResponseOutputIsAssetContentEncodedDeflate()
+		{
+			bundles.Add(new TestableBundle("~/test")
+			{
+				ContentType = "CONTENT/TYPE"
+			});
+			var asset = new Mock<IAsset>();
+			asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
+				 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
+			asset.SetupGet(a => a.Path)
+				 .Returns("~/test/asset.js");
+			asset.Setup(a => a.OpenStream())
+				 .Returns(() => "output".AsStream());
+			bundles.First().Assets.Add(asset.Object);
+			requestHeaders.Add("Accept-Encoding", "deflate");
+			response.SetupGet(r => r.Filter).Returns(Stream.Null);
 
-            using (outputStream = new MemoryStream())
-            {
-                requestHeaders.Add("If-None-Match", "\"010203\"");
-                handler.ProcessRequest("~/test/asset.js");
-            }
+			using (outputStream = new MemoryStream())
+			{
+				handler.ProcessRequest("~/test/asset.js");
 
-            response.VerifySet(r => r.StatusCode = 304);
-        }
+				Encoding.UTF8.GetString(outputStream.ToArray()).ShouldEqual("output");
+				response.VerifySet(r => r.Filter = It.IsAny<DeflateStream>());
+				response.Verify(r => r.AppendHeader("Content-Encoding", "deflate"));
+				response.Verify(r => r.AppendHeader("Vary", "Accept-Encoding"));
+			}
+		}
 
-        [Fact]
-        public void GivenRequestWithDifferingHash_WhenProcessRequest_ThenReturn3NoCacheResponse() {
-            bundles.Add(new TestableBundle("~/test"));
-            var asset = new StubAsset("~/test/asset.js", hash: new byte[] { 1, 2, 3 });
-            bundles.First().Assets.Add(asset);
+		[Fact]
+		public void GivenAssetExists_WhenProcessRequestWithEncodingGZip_ThenResponseOutputIsAssetContentEncodedGZip()
+		{
+			bundles.Add(new TestableBundle("~/test")
+			{
+				ContentType = "CONTENT/TYPE"
+			});
+			var asset = new Mock<IAsset>();
+			asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
+				 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
+			asset.SetupGet(a => a.Path)
+				 .Returns("~/test/asset.js");
+			asset.Setup(a => a.OpenStream())
+				 .Returns(() => "output".AsStream());
+			bundles.First().Assets.Add(asset.Object);
+			requestHeaders.Add("Accept-Encoding", "gzip");
+			response.SetupGet(r => r.Filter).Returns(Stream.Null);
 
-            request.SetupGet(x => x.RawUrl).Returns("~/test/HASH-MISMATCH/asset.js");
-            using(outputStream = new MemoryStream()) {
-                requestHeaders.Add("If-None-Match", "\"010203\"");
-                handler.ProcessRequest("~/test/asset.js");
-            }
+			using (outputStream = new MemoryStream())
+			{
+				handler.ProcessRequest("~/test/asset.js");
 
-            response.VerifySet(r => r.CacheControl = "no-cache");
-        }
-    }
+				Encoding.UTF8.GetString(outputStream.ToArray()).ShouldEqual("output");
+				response.VerifySet(r => r.Filter = It.IsAny<GZipStream>());
+				response.Verify(r => r.AppendHeader("Content-Encoding", "gzip"));
+				response.Verify(r => r.AppendHeader("Vary", "Accept-Encoding"));
+			}
+		}
+
+		[Fact]
+		public void GivenRequestWithMatchingETag_WhenProcessRequest_ThenReturn304NotModifiedResponse()
+		{
+			bundles.Add(new TestableBundle("~/test"));
+			var asset = new StubAsset("~/test/asset.js", hash: new byte[] { 1, 2, 3 });
+			bundles.First().Assets.Add(asset);
+
+			using (outputStream = new MemoryStream())
+			{
+				requestHeaders.Add("If-None-Match", "\"010203\"");
+				handler.ProcessRequest("~/test/asset.js");
+			}
+
+			response.VerifySet(r => r.StatusCode = 304);
+		}
+
+		[Fact]
+		public void GivenRequestWithDifferingHash_WhenProcessRequest_ThenReturn3NoCacheResponse()
+		{
+			bundles.Add(new TestableBundle("~/test"));
+			var asset = new StubAsset("~/test/asset.js", hash: new byte[] { 1, 2, 3 });
+			bundles.First().Assets.Add(asset);
+
+			request.SetupGet(x => x.RawUrl).Returns("~/test/HASH-MISMATCH/asset.js");
+			using (outputStream = new MemoryStream())
+			{
+				requestHeaders.Add("If-None-Match", "\"010203\"");
+				handler.ProcessRequest("~/test/asset.js");
+			}
+
+			response.VerifySet(r => r.CacheControl = "no-cache");
+		}
+	}
 }

--- a/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/BundleRequestHandler.cs
@@ -57,6 +57,23 @@ namespace Cassette.Aspnet
             );
         }
 
+		internal AssetRequestHandler CreateAssetRequestHandler()
+        {
+            return new AssetRequestHandler(
+                requestContext,
+                bundles
+            );
+        }
+
+		internal CachedFileRequestHandler CreateCachedFileRequestHandler()
+		{
+			return new CachedFileRequestHandler(
+				request.Object,
+				response.Object,
+				new FakeFileSystem()
+			);
+		}
+
         protected void SetupTestBundle()
         {
             var bundle = new TestableBundle("~/test");
@@ -337,12 +354,6 @@ namespace Cassette.Aspnet
 
             var handler = CreateRequestHandler();
             handler.ProcessRequest("~/test");
-        }
-
-        [Fact]
-        public void ResponseFilterIsNotSet()
-        {
-            response.VerifySet(r => r.Filter = It.IsAny<Stream>(), Times.Once()); // Only set once in the test constructor.
         }
     }
 }

--- a/src/Cassette.Aspnet.UnitTests/CachedFileRequestHandler.cs
+++ b/src/Cassette.Aspnet.UnitTests/CachedFileRequestHandler.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Specialized;
 using System.IO;
+using System.IO.Compression;
 using System.Web;
 using Moq;
 using Should;
@@ -14,18 +16,23 @@ namespace Cassette.Aspnet
         readonly Mock<HttpResponseBase> response;
         readonly FakeFileSystem cacheDirectory;
         readonly Mock<HttpCachePolicyBase> cache;
+		readonly Mock<HttpRequestBase> request;
+		readonly NameValueCollection requestHeaders;
 
         public CachedFileRequestHandler_ProcessRequestTests()
         {
-            cacheDirectory = new FakeFileSystem();
-
+			cacheDirectory = new FakeFileSystem();
+			request = new Mock<HttpRequestBase>();
+			requestHeaders = new NameValueCollection();
+			
             response = new Mock<HttpResponseBase>();
             outputStream = new MemoryStream();
             response.SetupGet(r => r.OutputStream).Returns(outputStream);
             cache = new Mock<HttpCachePolicyBase>();
-            response.SetupGet(r => r.Cache).Returns(cache.Object);
+			response.SetupGet(r => r.Cache).Returns(cache.Object);
+			request.SetupGet(r => r.Headers).Returns(requestHeaders);
 
-            handler = new CachedFileRequestHandler(response.Object, cacheDirectory);
+            handler = new CachedFileRequestHandler(request.Object, response.Object, cacheDirectory);
         }
 
         [Fact]
@@ -34,6 +41,34 @@ namespace Cassette.Aspnet
             cacheDirectory.Add("~/file.png", new byte[] { 1, 2, 3 });
             handler.ProcessRequest("~/file.png");
             outputStream.ToArray().ShouldEqual(new byte[] { 1, 2, 3 });
+        }
+
+        [Fact]
+        public void GivenRequestContainsEncodingGZip_WritesCacheFileAsEncodedGZip()
+        {
+			cacheDirectory.Add("~/file.png", new byte[] { 1, 2, 3 });
+			requestHeaders.Add("Accept-Encoding", "gzip");
+			response.SetupGet(r => r.Filter).Returns(Stream.Null);
+
+            handler.ProcessRequest("~/file.png");
+
+			response.VerifySet(r => r.Filter = It.IsAny<GZipStream>());
+			response.Verify(r => r.AppendHeader("Content-Encoding", "gzip"));
+			response.Verify(r => r.AppendHeader("Vary", "Accept-Encoding"));
+        }
+
+        [Fact]
+		public void GivenRequestContainsEncodingDeflate_WritesCacheFileAsEncodedDeflate()
+        {
+			cacheDirectory.Add("~/file.png", new byte[] { 1, 2, 3 });
+			requestHeaders.Add("Accept-Encoding", "deflate");
+			response.SetupGet(r => r.Filter).Returns(Stream.Null);
+
+            handler.ProcessRequest("~/file.png");
+
+			response.VerifySet(r => r.Filter = It.IsAny<DeflateStream>());
+			response.Verify(r => r.AppendHeader("Content-Encoding", "deflate"));
+			response.Verify(r => r.AppendHeader("Vary", "Accept-Encoding"));
         }
 
         [Fact]

--- a/src/Cassette.Aspnet/BundleRequestHandler.cs
+++ b/src/Cassette.Aspnet/BundleRequestHandler.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
+﻿using System.Linq;
 using System.Net;
 using System.Web;
 using System.Web.Routing;
@@ -61,7 +58,7 @@ namespace Cassette.Aspnet
 
         void SendNotModified(string actualETag)
         {
-            CacheLongTime(actualETag); // Some browsers seem to require a reminder to keep caching?!
+			HttpResponseUtil.CacheLongTime(response, actualETag); // Some browsers seem to require a reminder to keep caching?!
             response.StatusCode = 304; // Not Modified
             response.SuppressContent = true;
         }
@@ -71,85 +68,19 @@ namespace Cassette.Aspnet
             response.ContentType = bundle.ContentType;
             if(request.RawUrl.Contains(bundle.Hash.ToHexString()))
             {
-                CacheLongTime(actualETag);
+				HttpResponseUtil.CacheLongTime(response, actualETag);
             }
             else
             {
-                NoCache();
+				HttpResponseUtil.NoCache(response);
             }
 
-            var encoding = request.Headers["Accept-Encoding"];
-            response.Filter = EncodeStreamAndAppendResponseHeaders(response.Filter, encoding);
+			HttpResponseUtil.EncodeStreamAndAppendResponseHeaders(request, response);
 
             using (var assetStream = bundle.OpenStream())
             {
                 assetStream.CopyTo(response.OutputStream);
             }
-        }
-
-        void CacheLongTime(string actualETag)
-        {
-            response.Cache.SetCacheability(HttpCacheability.Public);
-            response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
-            response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
-            response.Cache.SetETag(actualETag);
-        }
-
-        void NoCache()
-        {
-            response.AddHeader("Pragma", "no-cache");
-            response.CacheControl = "no-cache";
-            response.Expires = -1;
-        }
-
-        Stream EncodeStreamAndAppendResponseHeaders(Stream stream, string acceptEncoding)
-        {
-            if (acceptEncoding == null) return stream;
-
-            var preferredEncoding = ParsePreferredEncoding(acceptEncoding);
-            if (preferredEncoding == null) return stream;
-
-            response.AppendHeader("Content-Encoding", preferredEncoding);
-            response.AppendHeader("Vary", "Accept-Encoding");
-            if (preferredEncoding == "deflate")
-            {
-                return new DeflateStream(stream, CompressionMode.Compress, true);
-            }
-            if (preferredEncoding == "gzip")
-            {
-                return new GZipStream(stream, CompressionMode.Compress, true);
-            }
-
-            // This line should never be reached because we've filtered out unsupported encoding types.
-            // But the compiler doesn't know this. :)
-            throw new Exception("Unknown content encoding type \"" + preferredEncoding + "\".");
-        }
-
-        static readonly string[] AllowedEncodings = new[] { "gzip", "deflate" };
-
-        static string ParsePreferredEncoding(string acceptEncoding)
-        {
-            return acceptEncoding
-                .Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
-                .Select(type => type.Split(';'))
-                .Select(parts => new
-                {
-                    encoding = parts[0].Trim(),
-                    qvalue = ParseQValueFromSecondArrayElement(parts)
-                })
-                .Where(x => AllowedEncodings.Contains(x.encoding))
-                .OrderByDescending(x => x.qvalue)
-                .Select(x => x.encoding)
-                .FirstOrDefault();
-        }
-
-        static float ParseQValueFromSecondArrayElement(string[] parts)
-        {
-            const float defaultQValue = 1f;
-            if (parts.Length < 2) return defaultQValue;
-
-            float qvalue;
-            return float.TryParse(parts[1].Trim(), out qvalue) ? qvalue : defaultQValue;
         }
     }
 }

--- a/src/Cassette.Aspnet/Cassette.Aspnet.csproj
+++ b/src/Cassette.Aspnet/Cassette.Aspnet.csproj
@@ -79,6 +79,7 @@
     <Compile Include="DiagnosticBundleConfiguration.cs" />
     <Compile Include="CassetteHttpHandler.cs" />
     <Compile Include="HttpContextLifetimeProvider.cs" />
+    <Compile Include="HttpResponseUtil.cs" />
     <Compile Include="ICassetteRequestHandler.cs" />
     <Compile Include="IDiagnosticRequestHandler.cs" />
     <Compile Include="ContentTypes.cs" />

--- a/src/Cassette.Aspnet/HttpResponseUtil.cs
+++ b/src/Cassette.Aspnet/HttpResponseUtil.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Web;
+
+namespace Cassette.Aspnet
+{
+	internal static class HttpResponseUtil
+	{
+		public static void CacheLongTime(HttpResponseBase response, string actualETag)
+		{
+			response.Cache.SetCacheability(HttpCacheability.Public);
+			response.Cache.SetExpires(DateTime.UtcNow.AddYears(1));
+			response.Cache.SetMaxAge(new TimeSpan(365, 0, 0, 0));
+			response.Cache.SetETag(actualETag);
+		}
+
+		public static void NoCache(HttpResponseBase response)
+		{
+			response.AddHeader("Pragma", "no-cache");
+			response.CacheControl = "no-cache";
+			response.Expires = -1;
+		}
+
+		public static void SendNotModified(HttpResponseBase response)
+		{
+			response.StatusCode = 304; // Not Modified
+			response.SuppressContent = true;
+		}
+		
+		public static void EncodeStreamAndAppendResponseHeaders(HttpRequestBase request, HttpResponseBase response)
+		{
+			var encoding = request.Headers["Accept-Encoding"];
+			EncodeStreamAndAppendResponseHeaders(response, encoding);
+		}
+
+		public static void EncodeStreamAndAppendResponseHeaders(HttpResponseBase response, string acceptEncoding)
+		{
+			if (acceptEncoding == null) return;
+
+			var preferredEncoding = ParsePreferredEncoding(acceptEncoding);
+			if (preferredEncoding == null) return;
+
+			response.AppendHeader("Content-Encoding", preferredEncoding);
+			response.AppendHeader("Vary", "Accept-Encoding");
+			if (preferredEncoding == "deflate")
+			{
+				response.Filter = new DeflateStream(response.Filter, CompressionMode.Compress, true);
+			}
+			if (preferredEncoding == "gzip")
+			{
+				response.Filter = new GZipStream(response.Filter, CompressionMode.Compress, true);
+			}
+		}
+
+		static readonly string[] AllowedEncodings = new[] { "gzip", "deflate" };
+
+		static string ParsePreferredEncoding(string acceptEncoding)
+		{
+			return acceptEncoding
+				.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+				.Select(type => type.Split(';'))
+				.Select(parts => new
+				{
+					encoding = parts[0].Trim(),
+					qvalue = ParseQValueFromSecondArrayElement(parts)
+				})
+				.Where(x => AllowedEncodings.Contains(x.encoding))
+				.OrderByDescending(x => x.qvalue)
+				.Select(x => x.encoding)
+				.FirstOrDefault();
+		}
+
+		static float ParseQValueFromSecondArrayElement(string[] parts)
+		{
+			const float defaultQValue = 1f;
+			if (parts.Length < 2) return defaultQValue;
+
+			float qvalue;
+			return float.TryParse(parts[1].Trim(), out qvalue) ? qvalue : defaultQValue;
+		}
+	}
+}

--- a/src/Cassette.Aspnet/WebHost.cs
+++ b/src/Cassette.Aspnet/WebHost.cs
@@ -36,7 +36,7 @@ namespace Cassette.Aspnet
             Container.Register<ICassetteRequestHandler, AssetRequestHandler>("AssetRequestHandler").AsPerRequestSingleton(CreateRequestLifetimeProvider());
             Container.Register<ICassetteRequestHandler>(
                 (c, n) =>
-                new CachedFileRequestHandler(c.Resolve<HttpResponseBase>(), c.Resolve<CassetteSettings>().CacheDirectory),
+                new CachedFileRequestHandler(c.Resolve<HttpRequestBase>(), c.Resolve<HttpResponseBase>(), c.Resolve<CassetteSettings>().CacheDirectory),
                 "CachedFileRequestHandler"
             );
             Container.Register<ICassetteRequestHandler, BundleRequestHandler<Scripts.ScriptBundle>>("ScriptBundleRequestHandler").AsPerRequestSingleton(CreateRequestLifetimeProvider());


### PR DESCRIPTION
Added compression to the AssetRequestHandler and CachedFileRequestHandler.
Added unit tests to check the correct behaviour.
Moved some functions regarding response-headers into the HttpResponseUtil.

I hope you like the implementation. All unit tests are green.
