### PR TITLE
Avoiding double compression

### DIFF
--- a/src/Cassette.Aspnet/PlaceholderReplacingResponseFilter.cs
+++ b/src/Cassette.Aspnet/PlaceholderReplacingResponseFilter.cs
@@ -10,99 +10,130 @@ using Cassette.Utilities;
 
 namespace Cassette.Aspnet
 {
-    class PlaceholderReplacingResponseFilter : MemoryStream
-    {
-        public PlaceholderReplacingResponseFilter(Stream outputStream, Encoding outputEncoding, NameValueCollection responseHeaders, IPlaceholderTracker placeholderTracker)
-        {
-            this.outputStream = outputStream;
-            this.outputEncoding = outputEncoding;
-            this.responseHeaders = responseHeaders;
-            this.placeholderTracker = placeholderTracker;
-            bufferStream = new MemoryStream();
-        }
+	class PlaceholderReplacingResponseFilter : MemoryStream
+	{
+		public PlaceholderReplacingResponseFilter(Stream outputStream, Encoding outputEncoding, NameValueCollection responseHeaders, IPlaceholderTracker placeholderTracker)
+		{
+			var gzipStream = outputStream as GZipStream;
+			var deflateStream = outputStream as DeflateStream;
 
-        readonly Stream outputStream;
-        readonly Encoding outputEncoding;
-        readonly NameValueCollection responseHeaders;
-        readonly IPlaceholderTracker placeholderTracker;
-        readonly MemoryStream bufferStream;
-        bool hasWrittenToOutputStream;
+			// get the base stream if the outout stream is a compressor already.
+			// this can happen, when the top application is setting a compressor as the response filter
+			if (gzipStream != null)
+			{
+				this.outputStream = gzipStream.BaseStream;
+				decompressFirst = false;
+			}
+			else if (deflateStream != null)
+			{
+				this.outputStream = deflateStream.BaseStream;
+				decompressFirst = false;
+			}
+			else
+			{
+				this.outputStream = outputStream;
+				decompressFirst = true;
+			}
 
-        public override void Write(byte[] buffer, int offset, int count)
-        {
-            bufferStream.Write(buffer, offset, count);
-        }
+			this.outputEncoding = outputEncoding;
+			this.responseHeaders = responseHeaders;
+			this.placeholderTracker = placeholderTracker;
+			this.bufferStream = new MemoryStream();
+		}
 
-        public override void Close()
-        {
-            if (!hasWrittenToOutputStream)
-            {
-                WriteBufferedOutput();
-                hasWrittenToOutputStream = true;
-            }
+		readonly Stream outputStream;
+		readonly Encoding outputEncoding;
+		readonly NameValueCollection responseHeaders;
+		readonly IPlaceholderTracker placeholderTracker;
+		readonly bool decompressFirst;
 
-            base.Close();
-        }
+		readonly MemoryStream bufferStream;
+		bool hasWrittenToOutputStream;
 
-        void WriteBufferedOutput()
-        {
-            // The buffered stream may be compressed already.
-            // Detect this from the Content-Encoding header.
-            var contentEncoding = responseHeaders["Content-Encoding"] ?? "";
-            if (contentEncoding.IndexOf("gzip", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                WriteCompressedOutput((stream, mode) => new GZipStream(stream, mode));
-            }
-            else if (contentEncoding.IndexOf("deflate", StringComparison.OrdinalIgnoreCase) >= 0)
-            {
-                WriteCompressedOutput((stream, mode) => new DeflateStream(stream, mode));
-            }
-            else if (contentEncoding != "")
-            {
-                throw new Exception("Cannot process response with content encoding \"" + contentEncoding + "\".");
-            }
-            else
-            {
-                WriteUncompressedOutput();
-            }
-        }
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			bufferStream.Write(buffer, offset, count);
+		}
 
-        void WriteCompressedOutput(Func<Stream, CompressionMode, Stream> createCompressionStream)
-        {
-            // Decompress the buffered stream into an in memory stream.
-            bufferStream.Position = 0;
-            using (var decompressor = createCompressionStream(bufferStream, CompressionMode.Decompress))
-            using (var expandedOriginalStream = new MemoryStream())
-            {
-                decompressor.CopyTo(expandedOriginalStream);
+		public override void Close()
+		{
+			if (!hasWrittenToOutputStream)
+			{
+				WriteBufferedOutput();
+				hasWrittenToOutputStream = true;
+			}
 
-                // Replace placeholders in the original content
-                var replacedOutput = GetOutputWithPlaceholdersReplaced(expandedOriginalStream);
+			base.Close();
+		}
 
-                // Compress this updated content,
-                // sending it to the output stream.
-                using (var toCompress = new MemoryStream(outputEncoding.GetBytes(replacedOutput)))
-                using (var compressor = createCompressionStream(outputStream, CompressionMode.Compress))
-                {
-                    toCompress.CopyTo(compressor);
-                }
-            }
-        }
+		void WriteBufferedOutput()
+		{
+			// The buffered stream may be compressed already.
+			// Detect this from the Content-Encoding header.
+			var contentEncoding = responseHeaders["Content-Encoding"] ?? "";
+			if (contentEncoding.IndexOf("gzip", StringComparison.OrdinalIgnoreCase) >= 0)
+			{
+				WriteCompressedOutput((stream, mode) => new GZipStream(stream, mode));
+			}
+			else if (contentEncoding.IndexOf("deflate", StringComparison.OrdinalIgnoreCase) >= 0)
+			{
+				WriteCompressedOutput((stream, mode) => new DeflateStream(stream, mode));
+			}
+			else if (contentEncoding != "")
+			{
+				throw new Exception("Cannot process response with content encoding \"" + contentEncoding + "\".");
+			}
+			else
+			{
+				WriteUncompressedOutput();
+			}
+		}
 
-        void WriteUncompressedOutput()
-        {
-            var output = GetOutputWithPlaceholdersReplaced(bufferStream);
-            var outputBytes = outputEncoding.GetBytes(output);
-            if (outputBytes.Length > 0)
-            {
-                outputStream.Write(outputBytes, 0, outputBytes.Length);
-            }
-        }
+		void WriteCompressedOutput(Func<Stream, CompressionMode, Stream> createCompressionStream)
+		{
+			// Decompress the buffered stream into an in memory stream.
+			bufferStream.Position = 0;
+			string replacedOutput;
 
-        string GetOutputWithPlaceholdersReplaced(MemoryStream originalStream)
-        {
-            var originalOutput = outputEncoding.GetString(originalStream.ToArray());
-            return placeholderTracker.ReplacePlaceholders(originalOutput);
-        }
-    }
+			if (decompressFirst)
+			{
+				using (var decompressor = createCompressionStream(bufferStream, CompressionMode.Decompress))
+				using (var expandedOriginalStream = new MemoryStream())
+				{
+					// Replace placeholders in the original content
+					decompressor.CopyTo(expandedOriginalStream);
+					replacedOutput = GetOutputWithPlaceholdersReplaced(expandedOriginalStream);
+				}
+			}
+			else
+			{
+				// Replace placeholders in the original content
+				replacedOutput = GetOutputWithPlaceholdersReplaced(bufferStream);
+			}
+
+			// Compress this updated content,
+			// sending it to the output stream.
+			using (var toCompress = new MemoryStream(outputEncoding.GetBytes(replacedOutput)))
+			using (var compressor = createCompressionStream(outputStream, CompressionMode.Compress))
+			{
+				toCompress.CopyTo(compressor);
+			}
+		}
+
+		void WriteUncompressedOutput()
+		{
+			var output = GetOutputWithPlaceholdersReplaced(bufferStream);
+			var outputBytes = outputEncoding.GetBytes(output);
+			if (outputBytes.Length > 0)
+			{
+				outputStream.Write(outputBytes, 0, outputBytes.Length);
+			}
+		}
+
+		string GetOutputWithPlaceholdersReplaced(MemoryStream originalStream)
+		{
+			var originalOutput = outputEncoding.GetString(originalStream.ToArray());
+			return placeholderTracker.ReplacePlaceholders(originalOutput);
+		}
+	}
 }


### PR DESCRIPTION
If the Response.Filter property is set to a compressor (GZip, Deflate), there was a chance that the compression was applied twice or the preceeding decompress failed.
Now the type of the filter is checked and if it is a compressor, it will be discarded.
