### PR TITLE
Update dotless to 1.4.0

### DIFF
--- a/src/Cassette.Less/Cassette.Less.csproj
+++ b/src/Cassette.Less/Cassette.Less.csproj
@@ -62,8 +62,9 @@
     <ErrorReport>prompt</ErrorReport>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="dotless.ClientOnly">
-      <HintPath>$(SolutionDir)packages\DotlessClientOnly.1.3.1.0\lib\dotless.ClientOnly.dll</HintPath>
+    <Reference Include="dotless.ClientOnly, Version=1.4.0.0, Culture=neutral, PublicKeyToken=96b446c9e63eae34, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\DotlessClientOnly.1.4.0.0\lib\dotless.ClientOnly.dll</HintPath>
     </Reference>
     <Reference Include="Iesi.Collections">
       <HintPath>$(SolutionDir)packages\Iesi.Collections.3.3.2.4000\lib\Net35\Iesi.Collections.dll</HintPath>

--- a/src/Cassette.Less/LessCompiler.cs
+++ b/src/Cassette.Less/LessCompiler.cs
@@ -47,6 +47,7 @@ namespace Cassette.Stylesheets
                                     configuration.MinifyOutput,
                                     configuration.Debug,
                                     configuration.DisableVariableRedefines,
+                                    configuration.DisableColorCompression,
                                     configuration.KeepFirstSpecialComment,
                                     configuration.Plugins);
 
@@ -188,6 +189,8 @@ namespace Cassette.Stylesheets
             {
                 return directory.GetFile(fileName).Exists;
             }
+
+            public bool UseCacheDependencies { get { return true; } }
         }
     }
 }

--- a/src/Cassette.Less/packages.config
+++ b/src/Cassette.Less/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotlessClientOnly" version="1.3.1.0" targetFramework="net40-Client" />
+  <package id="DotlessClientOnly" version="1.4.0.0" targetFramework="net40-Client" />
   <package id="Iesi.Collections" version="3.3.2.4000" targetFramework="net40-Client" />
 </packages>


### PR DESCRIPTION
Updated dotless to 1.4.0 (fixes issues with compiling some new less syntax, notable with Bootstrap 3)

(switching to winless compiler may be the long term solution however...)
