### PR TITLE
Added support for including assets by relative path in bundle.txt

### DIFF
--- a/src/Cassette/BundleCollection.cs
+++ b/src/Cassette/BundleCollection.cs
@@ -1,3 +1,5 @@
+using Cassette.IO;
+using Cassette.Utilities;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -7,8 +9,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-using Cassette.IO;
-using Cassette.Utilities;
 using Trace = Cassette.Diagnostics.Trace;
 
 #if NET35
@@ -22,12 +22,12 @@ namespace Cassette
         readonly List<Bundle> bundles = new List<Bundle>();
         readonly CassetteSettings settings;
         readonly IFileSearchProvider fileSearchProvider;
-        readonly IBundleFactoryProvider bundleFactoryProvider; 
+        readonly IBundleFactoryProvider bundleFactoryProvider;
         readonly IBundleCollectionInitializer bundleCollectionInitializer;
         readonly ReaderWriterLockSlim readerWriterLock = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
         Dictionary<Bundle, HashedSet<Bundle>> bundleImmediateReferences;
         Exception initializationException;
-       
+
 
         public BundleCollection(CassetteSettings settings, IFileSearchProvider fileSearchProvider, IBundleFactoryProvider bundleFactoryProvider, IBundleCollectionInitializer bundleCollectionInitializer)
         {
@@ -73,7 +73,7 @@ namespace Cassette
                     bundleCollectionInitializer.Initialize(this);
                 }
 
-                if(InitializationException != null)
+                if (InitializationException != null)
                     throw new Exception("Bundle collection rebuild failed. See inner exception for details.", InitializationException);
 
                 // if we fixed the build error we need that lock back!
@@ -309,8 +309,38 @@ namespace Cassette
             if (descriptor == null)
             {
                 var descriptorFile = TryGetDescriptorFile<T>(directory);
+
                 descriptor = ReadOrCreateBundleDescriptor(descriptorFile);
+
+                if (descriptorFile.Exists && descriptor.AssetFilenames.Count > 0)
+                {
+                    List<IFile> filesList = null;
+
+                    var filesByPath = allFiles.ToDictionary(f => f.FullPath, StringComparer.OrdinalIgnoreCase);
+
+                    var source = settings.SourceDirectory;
+
+                    foreach (var filename in descriptor.AssetFilenames)
+                    {
+                        if (filename.IndexOf('*') == -1 && !filesByPath.ContainsKey(filename))
+                        {
+                            var file = source.GetFile(filename);
+
+                            if (file.Exists)
+                            {
+                                if (filesList == null)
+                                    filesList = new List<IFile>(allFiles);
+
+                                filesList.Add(file);
+                            }
+                        }
+                    }
+
+                    if (filesList != null)
+                        allFiles = filesList;
+                }
             }
+
             return bundleFactory.CreateBundle(applicationRelativePath, allFiles, descriptor);
         }
 
@@ -913,7 +943,7 @@ namespace Cassette
         static IEnumerable<Bundle> OrderForEqualityComparison(IEnumerable<Bundle> bundlesToOrder)
         {
             return bundlesToOrder.OrderBy(b => b.GetType().FullName).ThenBy(b => b.Path);
-        } 
+        }
 
         public IEnumerator<Bundle> GetEnumerator()
         {

--- a/src/Cassette/BundleFactoryBase.cs
+++ b/src/Cassette/BundleFactoryBase.cs
@@ -18,8 +18,7 @@ namespace Cassette
         public virtual T CreateBundle(string path, IEnumerable<IFile> allFiles, BundleDescriptor bundleDescriptor)
         {
             var bundle = CreateBundleCore(path, bundleDescriptor);
-            var filesArray = allFiles.ToArray();
-            AddAssets(bundle, filesArray, bundleDescriptor.AssetFilenames);
+            AddAssets(bundle, allFiles, bundleDescriptor.AssetFilenames);
             AddReferences(bundle, bundleDescriptor.References);
             SetIsSortedIfExplicitFilenames(bundle, bundleDescriptor.AssetFilenames);
             if (bundleDescriptor.IsFromFile)
@@ -31,7 +30,7 @@ namespace Cassette
 
         protected abstract T CreateBundleCore(string path, BundleDescriptor bundleDescriptor);
 
-        void AddAssets(Bundle bundle, IFile[] allFiles, IEnumerable<string> descriptorFilenames)
+        void AddAssets(Bundle bundle, IEnumerable<IFile> allFiles, IEnumerable<string> descriptorFilenames)
         {
             var remainingFiles = new HashedSet<IFile>(allFiles);
             var filesByPath = allFiles.ToDictionary(f => f.FullPath, StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
Sometimes you don't want to move files around into different directories to be able to create a bundle with them. For example, if you're pulling in jQuery via nuget, you probably want to leave the .js in ~/Scripts and create a jQuery bundle that references that .js and an external CDN url.

Before, adding files by directory (which was used for bundle.txt) only added files in that package directory, even if the bundle.txt included relative paths to other files (like ~/Scripts/jquery-1.11.0.js). I added an extra check on add to ensure that allFiles is properly populated with relative path references from Assets.

I also removed a couple of extra allocations done by unneeded .ToArray() calls.

This also fixes #244.
