### PR TITLE
Added support for setting page location for render in bundle.txt

### DIFF
--- a/src/Cassette.UnitTests/BundleCollection.Add.cs
+++ b/src/Cassette.UnitTests/BundleCollection.Add.cs
@@ -7,6 +7,7 @@ using Cassette.Scripts;
 using Moq;
 using Should;
 using Xunit;
+using Cassette.BundleProcessing;
 
 namespace Cassette
 {
@@ -124,6 +125,26 @@ namespace Cassette
             ));
         }
 
+        [Fact]
+        public void GivenBundleDescriptorFileWithLocation_WhenAdd_ThenDescriptorPassedToFactoryAndLocationSet()
+        {
+            bundleFactoryProvider
+                 .Setup(f => f.GetBundleFactory<ScriptBundle>())
+                 .Returns(new ScriptBundleFactory(() => Mock.Of<IBundlePipeline<ScriptBundle>>()));
+
+            File.WriteAllText(Path.Combine(tempDirectory, "bundle.txt"), "b.js\na.js\n[bundle]\npageLocation = head");
+
+            var fileA = StubFile("~/a.js");
+            var fileB = StubFile("~/b.js");
+            fileSearch
+                .Setup(s => s.FindFiles(It.IsAny<IDirectory>()))
+                .Returns(new[] { fileA, fileB });
+
+            bundles.Add<ScriptBundle>("~");
+            
+            bundles.First().PageLocation.ShouldEqual("head");
+        }
+        
         [Fact]
         public void GivenScriptBundleDescriptor_WhenAdd_ThenScriptDescriptorPassedToFactory()
         {

--- a/src/Cassette.UnitTests/BundleDescriptorReader.cs
+++ b/src/Cassette.UnitTests/BundleDescriptorReader.cs
@@ -158,6 +158,14 @@ namespace Cassette
         }
 
         [Fact]
+        public void GivenPageLocationSection_WhenRead_ThenResultHasPageLocation()
+        {
+            var reader = GetReader("[bundle]\npageLocation = head");
+            var result = reader.Read();
+            result.PageLocation.ShouldEqual("head");
+        }
+
+        [Fact]
         public void GivenExternalSectionWithMoreThanOneFallbackConditionLine_WhenRead_ThenThrowException()
         {
             var reader = GetReader("[external]\nurl = http://test.com/api1.js\nfallbackCondition = !window.API\nfallbackCondition = !window.API");

--- a/src/Cassette/BundleDescriptor.cs
+++ b/src/Cassette/BundleDescriptor.cs
@@ -15,6 +15,7 @@ namespace Cassette
         public List<string> References { get; private set; }
         public string ExternalUrl { get; set; }
         public string FallbackCondition { get; set; }
+        public string PageLocation { get; set; }
         public IFile File { get; set; }
 
         public bool IsFromFile

--- a/src/Cassette/BundleFactoryBase.cs
+++ b/src/Cassette/BundleFactoryBase.cs
@@ -19,13 +19,20 @@ namespace Cassette
         {
             var bundle = CreateBundleCore(path, bundleDescriptor);
             var filesArray = allFiles.ToArray();
+
             AddAssets(bundle, filesArray, bundleDescriptor.AssetFilenames);
             AddReferences(bundle, bundleDescriptor.References);
             SetIsSortedIfExplicitFilenames(bundle, bundleDescriptor.AssetFilenames);
+
             if (bundleDescriptor.IsFromFile)
             {
                 bundle.DescriptorFilePath = bundleDescriptor.File.FullPath;
             }
+            if (!string.IsNullOrWhiteSpace(bundleDescriptor.PageLocation))
+            {
+                bundle.PageLocation = bundleDescriptor.PageLocation;
+            }
+
             return bundle;
         }
 

--- a/src/Website/Views/Documentation/v1/Configuration/BundleDescriptorFile.cshtml
+++ b/src/Website/Views/Documentation/v1/Configuration/BundleDescriptorFile.cshtml
@@ -22,7 +22,7 @@ knockout.js</code></pre>
 file1.js
 *</code></pre>
 
-<h2>bundle references</h2>
+<h2>Bundle references</h2>
 <p>If your bundle depends on other bundles, then add a references section.</p>
 <pre><code>file1.js
 file2.js
@@ -30,6 +30,13 @@ file2.js
 [references]
 ~/scripts/lib
 ~/scripts/widgets</code></pre>
+
+<h2>Page location</h2>
+<p>You can set a page location for the bundle (for example if it is a script that needs to be rendered in &lt;head&gt; rather than &lt;body&gt;) by setting the pageLocation in the bundle section.</p>
+<pre><code>file1.js
+
+[bundle]
+pageLocation = head</code></pre>
 
 <h2>External bundles</h2>
 <p>


### PR DESCRIPTION
I realized there was no way to set page location in bundle.txt. I wanted to create a modernizr bundle that was rendered in head, so I added support for a [bundle] section with a pageLocation setting.

I switched that parsing regex to a static readonly compiled regex while I was at it.

Also added to docs.
