### PR TITLE
Support Handlebars templates

### DIFF
--- a/src/Cassette/Bundle.cs
+++ b/src/Cassette/Bundle.cs
@@ -114,7 +114,9 @@ namespace Cassette
             { "text/javascript", "js" },
             { "text/css", "css" },
             { "text/html", "htm" },
-            { "text/ng-template", "htm" }
+            { "text/ng-template", "htm" },
+            { "text/x-handlebars", "htm" },
+            { "text/x-handlebars-template", "htm"}
         };
 
         public IEnumerable<string> References


### PR DESCRIPTION
When you develop an Ember.js app you need to set `type="text/x-handlebars"` customizing the html bundle:

```
bundles.Add<HtmlTemplateBundle>("views/templates", c => { c.ContentType = "text/x-handlebars"; });
```

This only works in Debug. In Release you receive an exception (KeyNotFoundException) because that type isn't in the FileExtensionsByContentType Dictionary.

I have also added the common "text/x-handlebars-template" type that is shown on the Handlebars website examples.
