### PR TITLE
Use proper backreference syntax

### DIFF
--- a/src/Cassette/Stylesheets/ExpandCssUrlsAssetTransformer.cs
+++ b/src/Cassette/Stylesheets/ExpandCssUrlsAssetTransformer.cs
@@ -21,7 +21,7 @@ namespace Cassette.Stylesheets
         }
 
         static readonly Regex CssUrlRegex = new Regex(
-            @"\b url \s* \( \s* (?<quote>['""]?) (?<url>.*?) \<quote> \s* \)",
+            @"\b url \s* \( \s* (?<quote>['""]?) (?<url>.*?) \k<quote> \s* \)",
             RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace
         );
         static readonly Regex AbsoluteUrlRegex = new Regex(


### PR DESCRIPTION
`\<name>` is not a documented backreference syntax, and does not work on Mono. I have switched this to `\k<name>` which is the documented syntax that works on Mono.

Source: http://msdn.microsoft.com/en-us/library/thwdfzxy(v=vs.110).aspx
