### PR TITLE
Quotation marks around MSBuild path for MSBuild 12

### DIFF
--- a/src/Cassette.MSBuild/install.ps1
+++ b/src/Cassette.MSBuild/install.ps1
@@ -33,5 +33,5 @@ $buildProject = Get-MSBuildProject
 $target = $buildProject.Xml.AddTarget("Bundle")
 $target.AfterTargets = "Build"
 $task = $target.AddTask("Exec")
-$task.SetParameter("Command", '$(msbuildtoolspath)\msbuild.exe $(ProjectDirectory)cassette.targets /p:OutputPath=$(OutputPath) /t:Bundle /nr:false')
+$task.SetParameter("Command", '&quot;$(msbuildtoolspath)\msbuild.exe&quot; $(ProjectDirectory)cassette.targets /p:OutputPath=$(OutputPath) /t:Bundle /nr:false')
 $project.Save()

--- a/src/Cassette.MSBuild/install.ps1
+++ b/src/Cassette.MSBuild/install.ps1
@@ -33,5 +33,5 @@ $buildProject = Get-MSBuildProject
 $target = $buildProject.Xml.AddTarget("Bundle")
 $target.AfterTargets = "Build"
 $task = $target.AddTask("Exec")
-$task.SetParameter("Command", '&quot;$(msbuildtoolspath)\msbuild.exe&quot; $(ProjectDirectory)cassette.targets /p:OutputPath=$(OutputPath) /t:Bundle /nr:false')
+$task.SetParameter("Command", '"$(msbuildtoolspath)\msbuild.exe" $(ProjectDirectory)cassette.targets /p:OutputPath=$(OutputPath) /t:Bundle /nr:false')
 $project.Save()


### PR DESCRIPTION
I was seeing this while converting my site to use Cassette:

```
C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe Daniel15.Web\cassette.targets /p:OutputPath=Daniel15.Web\obj\Release\Package\PackageTmp\ /t:Bundle /nr:false

'C:\Program' is not recognized as an internal or external command, operable program or batch file.
```

Since MSBuild 12 (used by Visual Studio 2013) is at `C:\Program Files (x86)\MSBuild\12.0\bin\msbuild.exe`, you need to wrap the path in quotation marks.
