### PR TITLE
Added exception handling to host.Initialize() to catch actual exception

### DIFF
--- a/src/Cassette.MSBuild/CreateBundlesCommand.cs
+++ b/src/Cassette.MSBuild/CreateBundlesCommand.cs
@@ -29,7 +29,16 @@ namespace Cassette.MSBuild
         {
             using (var host = new MSBuildHost(source, bin, output, appVirtualPath, includeRawFiles, taskLoggingHelper))
             {
-                host.Initialize();
+                try
+                {
+                    host.Initialize();
+                }
+                catch (Exception exception)
+                {
+                    taskLoggingHelper.LogError(exception.ToString());
+                    throw;
+                }
+                
                 host.Execute();
             }
         }


### PR DESCRIPTION
When there isn't a catch there, the exception will bubble as a SerializationException. With this catch we can see what's actually going wrong.

See: https://groups.google.com/forum/#!topic/cassette/FnYLQbG71X4
