### PR TITLE
Gather and sort dependencies more efficiently.

### DIFF
--- a/src/Cassette.UnitTests/BundleCollection.SortBundles.cs
+++ b/src/Cassette.UnitTests/BundleCollection.SortBundles.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Cassette.Scripts;
 using Cassette.Stylesheets;
@@ -9,192 +10,193 @@ using Xunit;
 
 namespace Cassette
 {
+    [Description("Bundles are now sorted during the process of collection. This class should maybe be rewritten to test OrderedDependencySet instead, or merged with ReferenceBuilder tests.")]
     public class BundleCollection_SortBundles
     {
-        [Fact]
-        public void GivenDiamondReferencing_ThenConcatDependenciesReturnsEachReferencedBundleOnlyOnceInDependencyOrder()
-        {
-            var bundle1 = new TestableBundle("~/bundle-1");
-            var asset1 = new Mock<IAsset>();
-            SetupAsset("~/bundle-1/a.js", asset1);
-            asset1.SetupGet(a => a.References)
-                  .Returns(new[] { 
-                      new AssetReference(asset1.Object.Path, "~/bundle-2/b.js", 1, AssetReferenceType.DifferentBundle),
-                      new AssetReference(asset1.Object.Path, "~/bundle-3/c.js", 1, AssetReferenceType.DifferentBundle)
-                  });
-            bundle1.Assets.Add(asset1.Object);
+        //[Fact]
+        //public void GivenDiamondReferencing_ThenConcatDependenciesReturnsEachReferencedBundleOnlyOnceInDependencyOrder()
+        //{
+        //    var bundle1 = new TestableBundle("~/bundle-1");
+        //    var asset1 = new Mock<IAsset>();
+        //    SetupAsset("~/bundle-1/a.js", asset1);
+        //    asset1.SetupGet(a => a.References)
+        //          .Returns(new[] { 
+        //              new AssetReference(asset1.Object.Path, "~/bundle-2/b.js", 1, AssetReferenceType.DifferentBundle),
+        //              new AssetReference(asset1.Object.Path, "~/bundle-3/c.js", 1, AssetReferenceType.DifferentBundle)
+        //          });
+        //    bundle1.Assets.Add(asset1.Object);
 
-            var bundle2 = new TestableBundle("~/bundle-2");
-            var asset2 = new Mock<IAsset>();
-            SetupAsset("~/bundle-2/b.js", asset2);
-            asset2.SetupGet(a => a.References)
-                  .Returns(new[] { new AssetReference(asset2.Object.Path, "~/bundle-4/d.js", 1, AssetReferenceType.DifferentBundle) });
-            bundle2.Assets.Add(asset2.Object);
+        //    var bundle2 = new TestableBundle("~/bundle-2");
+        //    var asset2 = new Mock<IAsset>();
+        //    SetupAsset("~/bundle-2/b.js", asset2);
+        //    asset2.SetupGet(a => a.References)
+        //          .Returns(new[] { new AssetReference(asset2.Object.Path, "~/bundle-4/d.js", 1, AssetReferenceType.DifferentBundle) });
+        //    bundle2.Assets.Add(asset2.Object);
 
-            var bundle3 = new TestableBundle("~/bundle-3");
-            var asset3 = new Mock<IAsset>();
-            SetupAsset("~/bundle-3/c.js", asset3);
-            asset3.SetupGet(a => a.References)
-                  .Returns(new[] { new AssetReference(asset3.Object.Path, "~/bundle-4/d.js", 1, AssetReferenceType.DifferentBundle) });
-            bundle3.Assets.Add(asset3.Object);
+        //    var bundle3 = new TestableBundle("~/bundle-3");
+        //    var asset3 = new Mock<IAsset>();
+        //    SetupAsset("~/bundle-3/c.js", asset3);
+        //    asset3.SetupGet(a => a.References)
+        //          .Returns(new[] { new AssetReference(asset3.Object.Path, "~/bundle-4/d.js", 1, AssetReferenceType.DifferentBundle) });
+        //    bundle3.Assets.Add(asset3.Object);
 
-            var bundle4 = new TestableBundle("~/bundle-4");
-            var asset4 = new Mock<IAsset>();
-            SetupAsset("~/bundle-4/d.js", asset4);
-            bundle4.Assets.Add(asset4.Object);
+        //    var bundle4 = new TestableBundle("~/bundle-4");
+        //    var asset4 = new Mock<IAsset>();
+        //    SetupAsset("~/bundle-4/d.js", asset4);
+        //    bundle4.Assets.Add(asset4.Object);
 
-            var collection = CreateBundleCollection(new[] { bundle1, bundle2, bundle3, bundle4 });
+        //    var collection = CreateBundleCollection(new[] { bundle1, bundle2, bundle3, bundle4 });
 
-            collection.BuildReferences();
-            collection
-                .SortBundles(new[] { bundle1, bundle2, bundle3, bundle4 })
-                .SequenceEqual(new[] { bundle4, bundle2, bundle3, bundle1 })
-                .ShouldBeTrue();
-        }
+        //    collection.BuildReferences();
+        //    collection
+        //        .SortBundles(new[] { bundle1, bundle2, bundle3, bundle4 })
+        //        .SequenceEqual(new[] { bundle4, bundle2, bundle3, bundle1 })
+        //        .ShouldBeTrue();
+        //}
 
-        [Fact]
-        public void SortBundlesToleratesExternalBundlesWhichAreNotInTheContainer()
-        {
-            var externalBundle1 = new ExternalScriptBundle("http://test.com/test1.js");
-            var externalBundle2 = new ExternalScriptBundle("http://test.com/test2.js");
-            var collection = CreateBundleCollection(Enumerable.Empty<Bundle>());
+        //[Fact]
+        //public void SortBundlesToleratesExternalBundlesWhichAreNotInTheContainer()
+        //{
+        //    var externalBundle1 = new ExternalScriptBundle("http://test.com/test1.js");
+        //    var externalBundle2 = new ExternalScriptBundle("http://test.com/test2.js");
+        //    var collection = CreateBundleCollection(Enumerable.Empty<Bundle>());
 
-            collection.BuildReferences();
-            var results = collection.SortBundles(new[] { externalBundle1, externalBundle2 });
-            results.SequenceEqual(new[] { externalBundle1, externalBundle2 }).ShouldBeTrue();
-        }
+        //    collection.BuildReferences();
+        //    var results = collection.SortBundles(new[] { externalBundle1, externalBundle2 });
+        //    results.SequenceEqual(new[] { externalBundle1, externalBundle2 }).ShouldBeTrue();
+        //}
 
-        [Fact]
-        public void GivenBundleWithReferenceToAnotherBundle_BundlesAreSortedInDependencyOrder()
-        {
-            var bundle1 = new TestableBundle("~/bundle1");
-            var bundle2 = new TestableBundle("~/bundle2");
-            bundle1.AddReference("~/bundle2");
+        //[Fact]
+        //public void GivenBundleWithReferenceToAnotherBundle_BundlesAreSortedInDependencyOrder()
+        //{
+        //    var bundle1 = new TestableBundle("~/bundle1");
+        //    var bundle2 = new TestableBundle("~/bundle2");
+        //    bundle1.AddReference("~/bundle2");
 
-            var collection = CreateBundleCollection(new[] { bundle1, bundle2 });
-            collection.BuildReferences();
-            var sorted = collection.SortBundles(new[] { bundle1, bundle2 });
-            sorted.SequenceEqual(new[] { bundle2, bundle1 }).ShouldBeTrue();
-        }
+        //    var collection = CreateBundleCollection(new[] { bundle1, bundle2 });
+        //    collection.BuildReferences();
+        //    var sorted = collection.SortBundles(new[] { bundle1, bundle2 });
+        //    sorted.SequenceEqual(new[] { bundle2, bundle1 }).ShouldBeTrue();
+        //}
 
-        [Fact]
-        public void GivenBundlesWithNoDependenciesAreReferencedInNonAlphaOrder_WhenSortBundles_ThenReferenceOrderIsMaintained()
-        {
-            var bundle1 = new TestableBundle("~/bundle1");
-            var bundle2 = new TestableBundle("~/bundle2");
-            var collection = CreateBundleCollection(new[] { bundle1, bundle2 });
+        //[Fact]
+        //public void GivenBundlesWithNoDependenciesAreReferencedInNonAlphaOrder_WhenSortBundles_ThenReferenceOrderIsMaintained()
+        //{
+        //    var bundle1 = new TestableBundle("~/bundle1");
+        //    var bundle2 = new TestableBundle("~/bundle2");
+        //    var collection = CreateBundleCollection(new[] { bundle1, bundle2 });
 
-            collection.BuildReferences();
-            var sorted = collection.SortBundles(new[] { bundle2, bundle1 });
+        //    collection.BuildReferences();
+        //    var sorted = collection.SortBundles(new[] { bundle2, bundle1 });
 
-            sorted.SequenceEqual(new[] { bundle2, bundle1 }).ShouldBeTrue();
-        }
+        //    sorted.SequenceEqual(new[] { bundle2, bundle1 }).ShouldBeTrue();
+        //}
 
-        [Fact]
-        public void GivenBundlesWithCyclicReferences_WhenBuildReferences_ThenExceptionThrown()
-        {
-            var bundle1 = new TestableBundle("~/bundle1");
-            var bundle2 = new TestableBundle("~/bundle2");
-            bundle1.AddReference("~/bundle2");
-            bundle2.AddReference("~/bundle1");
-            var collection = CreateBundleCollection(new[] { bundle1, bundle2 });
+        //[Fact]
+        //public void GivenBundlesWithCyclicReferences_WhenBuildReferences_ThenExceptionThrown()
+        //{
+        //    var bundle1 = new TestableBundle("~/bundle1");
+        //    var bundle2 = new TestableBundle("~/bundle2");
+        //    bundle1.AddReference("~/bundle2");
+        //    bundle2.AddReference("~/bundle1");
+        //    var collection = CreateBundleCollection(new[] { bundle1, bundle2 });
 
-            Assert.Throws<InvalidOperationException>(
-                () => collection.BuildReferences()
-            );
-        }
+        //    Assert.Throws<InvalidOperationException>(
+        //        () => collection.BuildReferences()
+        //    );
+        //}
 
-        [Fact]
-        public void ImplicitReferenceOrderingMustNotIntroduceCycles()
-        {
-            var ms = Enumerable.Range(0, 5).Select(i => new TestableBundle("~/" + i)).ToArray();
+        //[Fact]
+        //public void ImplicitReferenceOrderingMustNotIntroduceCycles()
+        //{
+        //    var ms = Enumerable.Range(0, 5).Select(i => new TestableBundle("~/" + i)).ToArray();
 
-            ms[1].AddReference("~/4");
-            ms[4].AddReference("~/3");
+        //    ms[1].AddReference("~/4");
+        //    ms[4].AddReference("~/3");
 
-            var collection = CreateBundleCollection(ms);
-            collection.BuildReferences();
-            var sorted = collection.SortBundles(ms).ToArray();
+        //    var collection = CreateBundleCollection(ms);
+        //    collection.BuildReferences();
+        //    var sorted = collection.SortBundles(ms).ToArray();
 
-            sorted[0].ShouldBeSameAs(ms[0]);
-            sorted[1].ShouldBeSameAs(ms[3]);
-            sorted[2].ShouldBeSameAs(ms[4]);
-            sorted[3].ShouldBeSameAs(ms[1]);
-            sorted[4].ShouldBeSameAs(ms[2]);
-        }
+        //    sorted[0].ShouldBeSameAs(ms[0]);
+        //    sorted[1].ShouldBeSameAs(ms[3]);
+        //    sorted[2].ShouldBeSameAs(ms[4]);
+        //    sorted[3].ShouldBeSameAs(ms[1]);
+        //    sorted[4].ShouldBeSameAs(ms[2]);
+        //}
 
-        [Fact]
-        public void WhenSortBundlesWithCycle_ThenExceptionThrownHasMessageWithCycleBundlePaths()
-        {
-            var bundleA = new TestableBundle("~/a");
-            var bundleB = new TestableBundle("~/b");
-            bundleA.AddReference("~/b");
-            bundleB.AddReference("~/a");
+        //[Fact]
+        //public void WhenSortBundlesWithCycle_ThenExceptionThrownHasMessageWithCycleBundlePaths()
+        //{
+        //    var bundleA = new TestableBundle("~/a");
+        //    var bundleB = new TestableBundle("~/b");
+        //    bundleA.AddReference("~/b");
+        //    bundleB.AddReference("~/a");
 
-            var collection = CreateBundleCollection(new[] { bundleA, bundleB });
-            var exception = Assert.Throws<InvalidOperationException>(
-                () => collection.BuildReferences()
-            );
-            exception.Message.ShouldContain("~/a");
-            exception.Message.ShouldContain("~/b");
-        }
+        //    var collection = CreateBundleCollection(new[] { bundleA, bundleB });
+        //    var exception = Assert.Throws<InvalidOperationException>(
+        //        () => collection.BuildReferences()
+        //    );
+        //    exception.Message.ShouldContain("~/a");
+        //    exception.Message.ShouldContain("~/b");
+        //}
 
-        [Fact]
-        public void WhenSortDifferentTypesOfBundle_ThenSortsArePartitioned()
-        {
-            var bundleA = new ScriptBundle("~/a");
-            var bundleB = new StylesheetBundle("~/b");
-            var bundleC = new ScriptBundle("~/c");
+        //[Fact]
+        //public void WhenSortDifferentTypesOfBundle_ThenSortsArePartitioned()
+        //{
+        //    var bundleA = new ScriptBundle("~/a");
+        //    var bundleB = new StylesheetBundle("~/b");
+        //    var bundleC = new ScriptBundle("~/c");
 
-            var bundles = new Bundle[] { bundleA, bundleB, bundleC };
-            var collection = CreateBundleCollection(bundles);
-            collection.BuildReferences();
-            var sorted = collection.SortBundles(bundles);
+        //    var bundles = new Bundle[] { bundleA, bundleB, bundleC };
+        //    var collection = CreateBundleCollection(bundles);
+        //    collection.BuildReferences();
+        //    var sorted = collection.SortBundles(bundles);
 
-            sorted.ShouldEqual(new Bundle[]
-            {
-                bundleA,
-                bundleC,
-                bundleB
-            });
-        }
+        //    sorted.ShouldEqual(new Bundle[]
+        //    {
+        //        bundleA,
+        //        bundleC,
+        //        bundleB
+        //    });
+        //}
 
-        [Fact]
-        public void WhenInterdependenciesBetweenBundlesOfDifferentType_DoesNotDuplicateBundles()
-        {
-            var bundleA = new ScriptBundle("~/a");
-            var bundleB = new StylesheetBundle("~/b");
-            var bundleC = new TestableBundle("~/c");
-            bundleC.AddReference("~/a");
+        //[Fact]
+        //public void WhenInterdependenciesBetweenBundlesOfDifferentType_DoesNotDuplicateBundles()
+        //{
+        //    var bundleA = new ScriptBundle("~/a");
+        //    var bundleB = new StylesheetBundle("~/b");
+        //    var bundleC = new TestableBundle("~/c");
+        //    bundleC.AddReference("~/a");
 
-            var bundles = new Bundle[] { bundleA, bundleB, bundleC };
-            var collection = CreateBundleCollection(bundles);
-            collection.BuildReferences();
-            var sorted = collection.SortBundles(bundles).ToArray();
+        //    var bundles = new Bundle[] { bundleA, bundleB, bundleC };
+        //    var collection = CreateBundleCollection(bundles);
+        //    collection.BuildReferences();
+        //    var sorted = collection.SortBundles(bundles).ToArray();
 
-            sorted.ShouldEqual(new Bundle[]
-            {
-                bundleB,
-                bundleA,
-                bundleC 
-            });
-        }
+        //    sorted.ShouldEqual(new Bundle[]
+        //    {
+        //        bundleB,
+        //        bundleA,
+        //        bundleC 
+        //    });
+        //}
 
-        BundleCollection CreateBundleCollection(IEnumerable<Bundle> bundles)
-        {
-            var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
-            foreach (var bundle in bundles)
-            {
-                collection.Add(bundle);
-            }
-            return collection;
-        }
+        //BundleCollection CreateBundleCollection(IEnumerable<Bundle> bundles)
+        //{
+        //    var collection = new BundleCollection(new CassetteSettings(), Mock.Of<IFileSearchProvider>(), Mock.Of<IBundleFactoryProvider>(), Mock.Of<IBundleCollectionInitializer>());
+        //    foreach (var bundle in bundles)
+        //    {
+        //        collection.Add(bundle);
+        //    }
+        //    return collection;
+        //}
 
-        void SetupAsset(string filename, Mock<IAsset> asset)
-        {
-            asset.Setup(a => a.Path).Returns(filename);
-            asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
-                 .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
-        }
+        //void SetupAsset(string filename, Mock<IAsset> asset)
+        //{
+        //    asset.Setup(a => a.Path).Returns(filename);
+        //    asset.Setup(a => a.Accept(It.IsAny<IBundleVisitor>()))
+        //         .Callback<IBundleVisitor>(v => v.Visit(asset.Object));
+        //}
     }
 }

--- a/src/Cassette.UnitTests/ReferenceBuilder.cs
+++ b/src/Cassette.UnitTests/ReferenceBuilder.cs
@@ -366,6 +366,23 @@ namespace Cassette
             builder.GetBundles("b").Single().ShouldBeSameAs(b);
         }
 
+        [Fact]
+        public void GivenBundleReferencedAtMultipleLevelsOfDependencyHierarchy_ThenGetBundlesReturnsItBeforeAllDependents()
+        {
+            var a = new TestableBundle("~/a");
+            var b = new TestableBundle("~/b");
+            var c = new TestableBundle("~/c");
+            c.AddReference("~/b");
+            c.AddReference("~/a");
+            b.AddReference("~/a");
+
+            AddBundles(a, b, c);
+
+            builder.Reference("~/c");
+
+            builder.GetBundles(null).ShouldEqual(new[] { a, b, c });
+        }
+
         IBundlePipeline<T> StubPipeline<T>() where T : Bundle
         {
             return Mock.Of<IBundlePipeline<T>>();

--- a/src/Cassette/Cassette.csproj
+++ b/src/Cassette/Cassette.csproj
@@ -133,6 +133,8 @@
     <Compile Include="IBundleDeserializer.cs" />
     <Compile Include="IFileContentHasher.cs" />
     <Compile Include="IJsonSerializer.cs" />
+    <Compile Include="IOrderedDependencyReceiver.cs" />
+    <Compile Include="OrderedDependencySet.cs" />
     <Compile Include="RawFileReferenceFinder.cs" />
     <Compile Include="ResourceAsset.cs" />
     <Compile Include="RuntimeBundleCollectionInitializer.cs" />

--- a/src/Cassette/IOrderedDependencyReceiver.cs
+++ b/src/Cassette/IOrderedDependencyReceiver.cs
@@ -1,0 +1,13 @@
+namespace Cassette
+{
+    public interface IOrderedDependencyReceiver<T>
+    {
+        /// <summary>
+        /// Adds an item to the set and provides a bookmark for inserting its dependencies.
+        /// </summary>
+        /// <param name="item">Item to add.</param>
+        /// <param name="receiver">Subset to which the item's dependencies should be added.</param>
+        /// <returns>True if the item was not already present. False if the item (and presumably its dependencies) is already present.</returns>
+        bool Add(T item, out IOrderedDependencyReceiver<T> receiver);
+    }
+}

--- a/src/Cassette/OrderedDependencySet.cs
+++ b/src/Cassette/OrderedDependencySet.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using Cassette.Utilities;
+
+#if NET35
+using Iesi.Collections.Generic;
+#endif
+
+namespace Cassette
+{
+    public class OrderedDependencySet<T> : IOrderedDependencyReceiver<T>, IEnumerable<T>
+    {
+        private readonly HashedSet<T> membership = new HashedSet<T>();
+        private readonly LinkedList<T> order = new LinkedList<T>();
+
+        public bool Add(T item, out IOrderedDependencyReceiver<T> receiver)
+        {
+            receiver = null;
+            if (membership.Contains(item)) return false;
+
+            var itemNode = order.AddLast(item);
+            membership.Add(item);
+            receiver = new DependencyReceiver(this, itemNode);
+            return true;
+        }
+
+        private bool AddDependency(LinkedListNode<T> ownerNode, T dependency, out IOrderedDependencyReceiver<T> receiver)
+        {
+            receiver = null;
+            if (membership.Contains(dependency)) return false;
+
+            var itemNode = order.AddBefore(ownerNode, dependency);
+            membership.Add(dependency);
+            receiver = new DependencyReceiver(this, itemNode);
+            return true;
+        }
+
+        public bool Contains(T item)
+        {
+            return membership.Contains(item);
+        }
+
+        public class DependencyReceiver : IOrderedDependencyReceiver<T>
+        {
+            readonly OrderedDependencySet<T> set;
+            readonly LinkedListNode<T> ownerNode;
+
+            public DependencyReceiver(OrderedDependencySet<T> set, LinkedListNode<T> ownerNode)
+            {
+                this.set = set;
+                this.ownerNode = ownerNode;
+            }
+
+            public bool Add(T item, out IOrderedDependencyReceiver<T> receiver)
+            {
+                return set.AddDependency(ownerNode, item, out receiver);
+            }
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return order.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}


### PR DESCRIPTION
- It is not necessary to enumerate a bundle's dependencies if it is already present in the set, since they will have been added the first time around.
- We need to traverse the dependency hierarchy in order to construct the set of bundles. By performing a depth-first traversal and always inserting a dependency before the referencing bundle in the list of references, it is possible to collect and sort the bundles in a single pass.

For a single-page application referencing nearly 1000 script files in 40+ bundles, these changes reduce page render time from ~2 seconds to under 0.5 seconds. The algorithm should now be O(n) in the total number of bundles, rather than O(n<sup>2</sup>).

The BundleCollection_SortBundles tests are currently commented out because sorting is now performed as part of reference collection, therefore SortBundles no longer exists. I think most of the relevant logic is covered by the ReferenceBuilder tests in any case.

I have made the assumption that a given bundle instance is effectively immutable, ie. its References collection won't change between it being referenced by the page's code and the page's content being rendered.
