### PR TITLE
Fix PlaceholderRewriter: Detect response as html response as well, if charset is set in response header content-type

### DIFF
--- a/src/Cassette.Aspnet.UnitTests/PlaceholderRewriter.cs
+++ b/src/Cassette.Aspnet.UnitTests/PlaceholderRewriter.cs
@@ -50,10 +50,34 @@ namespace Cassette.Aspnet
         }
 
         [Fact]
+        public void GivenWithCharsetCanRewriteOutput_WhenRewriteOutput_ThenPlaceholderReplacingResponseFilterSetForResponse()
+        {
+            settings.IsHtmlRewritingEnabled = true;
+            ContentType("text/html; charset=utf-8");
+            StatusCode(200);
+
+            rewriter.RewriteOutput();
+
+            response.VerifySet(r => r.Filter = It.IsAny<PlaceholderReplacingResponseFilter>());
+        }
+
+        [Fact]
         public void GivenXhtmlContentType_WhenRewriteOutput_ThenPlaceholderReplacingResponseFilterSetForResponse()
         {
             settings.IsHtmlRewritingEnabled = true;
             ContentType("application/xhtml+xml");
+            StatusCode(200);
+
+            rewriter.RewriteOutput();
+
+            response.VerifySet(r => r.Filter = It.IsAny<PlaceholderReplacingResponseFilter>());
+        }
+
+        [Fact]
+        public void GivenXhtmlContentTypeWithCharset_WhenRewriteOutput_ThenPlaceholderReplacingResponseFilterSetForResponse()
+        {
+            settings.IsHtmlRewritingEnabled = true;
+            ContentType("application/xhtml+xml; charset=utf-8");
             StatusCode(200);
 
             rewriter.RewriteOutput();

--- a/src/Cassette.Aspnet/PlaceholderRewriter.cs
+++ b/src/Cassette.Aspnet/PlaceholderRewriter.cs
@@ -58,8 +58,8 @@ namespace Cassette.Aspnet
 
         bool IsHtmlResponse(HttpContextBase httpContext)
         {
-            return httpContext.Response.ContentType == "text/html" ||
-                   httpContext.Response.ContentType == "application/xhtml+xml";
+            return httpContext.Response.ContentType.StartsWith("text/html") ||
+                   httpContext.Response.ContentType.StartsWith("application/xhtml+xml");
         }
     }
 }


### PR DESCRIPTION
Currently, the rendering of the assets from Cassette fails, if the response header (content-type) contains a charset. So, I got just the hash of the assets in the rendered html document.
